### PR TITLE
Optimize BFS

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearch.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearch.kt
@@ -3,21 +3,43 @@ package com.fueledbycaffeine.spotlight.buildscript.graph
 import java.util.*
 
 public object BreadthFirstSearch {
-  public fun <T: GraphNode<T>> flatten(nodes: Set<T>, rules: Set<ImplicitDependencyRule> = emptySet()): List<T> {
-    return run(nodes, rules).values.flatten().distinct()
+  // Initialize with generously sized capacities to avoid resizing as we grow
+  private const val INITIAL_CAPACITY = 4096
+
+  public fun <T : GraphNode<T>> flatten(nodes: Set<T>, rules: Set<ImplicitDependencyRule> = emptySet()): List<T> {
+    val deps = run(nodes, rules)
+    // In lieu of a flattenTo() option, this creates an intermediate
+    // set to avoid the intermediate list + distinct()
+    return buildList {
+      val seen = LinkedHashSet<T>(INITIAL_CAPACITY)
+      for (values in deps.values) {
+        for (dep in values) {
+          if (seen.add(dep)) {
+            add(dep)
+          }
+        }
+      }
+    }
   }
 
-  public fun <T: GraphNode<T>> run(nodes: Set<T>, rules: Set<ImplicitDependencyRule> = emptySet()): Map<T, Set<T>> {
-    val dependenciesMap = mutableMapOf<T, Set<T>>()
-    val queue = LinkedList<T>()
+  public fun <T : GraphNode<T>> run(nodes: Set<T>, rules: Set<ImplicitDependencyRule> = emptySet()): Map<T, Set<T>> {
+    // one set for all the visited bookkeeping
+    val seen = HashSet<T>(INITIAL_CAPACITY)
+    val dependenciesMap = LinkedHashMap<T, Set<T>>(INITIAL_CAPACITY)
+    val queue = ArrayDeque<T>(INITIAL_CAPACITY)
+
     queue.addAll(nodes)
+    seen += nodes
 
     while (queue.isNotEmpty()) {
-      val nextNode = queue.poll()
-      if (nextNode !in dependenciesMap) {
-        val successors = nextNode.findSuccessors(rules)
-        dependenciesMap[nextNode] = successors
-        queue.addAll(successors)
+      val nextNode = queue.removeFirst()
+      val successors = nextNode.findSuccessors(rules)
+      dependenciesMap[nextNode] = successors
+
+      for (successor in successors) {
+        if (seen.add(successor)) {
+          queue.addLast(successor)
+        }
       }
     }
 


### PR DESCRIPTION
Small but since it's critical path I figure might as well
- Swap LinkedList for the [faster](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayDeque.html#:~:text=This%20class%20is%20likely%20to%20be%20faster%20than%20Stack%20when%20used%20as%20a%20stack%2C%20and%20faster%20than%20LinkedList%20when%20used%20as%20a%20queue.) ArrayDeque
- Use a generous initial capacity for collections assuming this is going to be used on large projects and minimize resizing collections while growing.
- Track a `seen` set while processing to avoid queueing up duplicate or already-processed elements
- Flatten to a set rather than list + distinct (which then creates both a set and a new list).