### PR TITLE
Test for CC inputs being tracked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,5 +32,9 @@ dependencyAnalysis {
       includeDependency libs.autonomousapps.testkit.support
       includeDependency libs.truth
     }
+    bundle('moshi') {
+      primary libs.moshi
+      includeDependency 'com.squareup.moshi:moshi'
+    }
   }
 }

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
@@ -2,20 +2,18 @@ package com.fueledbycaffeine.spotlight.buildscript
 
 import com.fueledbycaffeine.spotlight.buildscript.graph.GraphNode
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
+import com.gradle.scan.plugin.internal.com.fueledbycaffeine.spotlight.internal.GradlePathInternal
 import java.io.File
 import java.io.FileNotFoundException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Locale.getDefault
-import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
-import kotlin.io.path.name
 import kotlin.io.path.relativeTo
 
 public const val GRADLE_PATH_SEP: String = ":"
 public const val GRADLE_SCRIPT: String = "build.gradle"
 public const val GRADLE_SCRIPT_KOTLIN: String = "build.gradle.kts"
 public val BUILDSCRIPTS: List<String> = listOf(GRADLE_SCRIPT, GRADLE_SCRIPT_KOTLIN)
+private val SRC_AND_BUILD_DIRS = listOf("build", "src", "src-gen")
 
 public data class GradlePath(
   public val root: Path,
@@ -34,19 +32,19 @@ public data class GradlePath(
   /**
    * Indicates if this project path has either a build.gradle or a build.gradle.kts script
    */
-  public val hasBuildFile: Boolean
-    get() = projectDir.resolve(GRADLE_SCRIPT).exists() ||
-      projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists()
+  public val hasBuildFile: Boolean get() = GradlePathInternal.hasBuildFile(this)
 
   /**
    * The buildscript [Path] for this Gradle path.
    *
    * @throws FileNotFoundException if there is no buildscript.
    */
-  public val buildFilePath: Path get() = when {
-    projectDir.resolve(GRADLE_SCRIPT).exists() -> projectDir.resolve(GRADLE_SCRIPT)
-    projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists() -> projectDir.resolve(GRADLE_SCRIPT_KOTLIN)
-    else -> throw FileNotFoundException("No build.gradle(.kts) for $path found")
+  public val buildFilePath: Path get() = try {
+    GradlePathInternal.buildFilePath(this)
+  } catch (_: GradlePathInternal.NoBuildFileException) {
+    // The package for GradlePathInternal is really weird and possibly confusing so make it look like the exception
+    // came from here in the public API.
+    throw FileNotFoundException("No build.gradle(.kts) for $path found")
   }
 
   /**
@@ -64,15 +62,10 @@ public data class GradlePath(
   public val isRootProject: Boolean get() = path == GRADLE_PATH_SEP
 
   /**
-   * Recursively walk the directory for this project and find all of the child projects.
+   * Recursively walk the directory for this project and find all the child projects.
    */
-  public fun expandChildProjects(excludeDirs: List<String> = listOf("build", "src")): Set<GradlePath> {
-    return Files.walk(projectDir).parallel()
-      .filter { it.name !in excludeDirs }
-      .filter { it.isDirectory() }
-      .filter { path -> BUILDSCRIPTS.any { path.resolve(it).exists() } }
-      .map { it.gradlePathRelativeTo(root) }
-      .toList().toSet()
+  public fun expandChildProjects(excludeDirs: List<String> = SRC_AND_BUILD_DIRS): Set<GradlePath> {
+    return GradlePathInternal.expandChildProjects(this, excludeDirs)
   }
 
   public override fun findSuccessors(rules: Set<ImplicitDependencyRule>): Set<GradlePath> {

--- a/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/GradlePathInternal.kt
+++ b/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/GradlePathInternal.kt
@@ -1,0 +1,66 @@
+/**
+ * Gradle provides a system property to exclude files matching patterns from being captured in configuration cache:
+ * https://github.com/gradle/gradle/blob/v8.14.1/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java#L551
+ * This doesn't work for the use case in Spotlight since it is a start parameter and therefore read before the plugin
+ * loads, so we can't set it with the plugin and would require the user to configure it.
+ *
+ * The other alternative is to pretend you are the build scan plugin:
+ * https://github.com/gradle/gradle/blob/v8.14.1/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/internal/cc/impl/Workarounds.kt#L77-L81
+ *
+ * That's what we're doing here because it just works (for now)
+ *
+ * So why do this? [GradlePathInternal.expandChildProjects] ends up observing filesystem entries besides
+ * `build.gradle(.kts)` because it uses [Files.newDirectoryStream], which can only filter files *after* observing them.
+ * All we want to do here is find `build.gradle(.kts)` which will be captured in CC elsewhere anyway.
+ *
+ * The extra file paths captured by CC don't seem to affect the reusability of the entry, but we want to keep that list
+ * as small as possible.
+ */
+package com.gradle.scan.plugin.internal.com.fueledbycaffeine.spotlight.internal
+
+import com.fueledbycaffeine.spotlight.buildscript.*
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.name
+
+/**
+ * [Files.walk] will recurse directories automatically, but the order of paths returned is not ordered in any way, so
+ * filtering the results can only be done after observing the filesystem entries, which ends up observing source/build
+ * files. This manual recursion will avoid traversing directories we want to completely ignore.
+ */
+private fun Path.findGradleBuildFiles(excludeDirs: List<String>): Set<Path> {
+  return Files.newDirectoryStream(this)
+    .use { stream ->
+      stream.flatMap { path ->
+        if (path.isDirectory() && path.name !in excludeDirs) {
+          path.findGradleBuildFiles(excludeDirs)
+        } else if (path.name in BUILDSCRIPTS) {
+          setOf(path)
+        } else {
+          emptySet()
+        }
+      }
+    }
+    .toCollection(mutableSetOf())
+}
+
+internal object GradlePathInternal {
+  fun expandChildProjects(gradlePath: GradlePath, excludeDirs: List<String>): Set<GradlePath> {
+    return gradlePath.projectDir.findGradleBuildFiles(excludeDirs)
+      .mapTo(mutableSetOf()) { it.parent.gradlePathRelativeTo(gradlePath.root) }
+  }
+
+  fun hasBuildFile(gradlePath: GradlePath): Boolean =
+    gradlePath.projectDir.resolve(GRADLE_SCRIPT).exists() ||
+    gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists()
+
+  fun buildFilePath(gradlePath: GradlePath): Path = when {
+    gradlePath.projectDir.resolve(GRADLE_SCRIPT).exists() -> gradlePath.projectDir.resolve(GRADLE_SCRIPT)
+    gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists() -> gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN)
+    else -> throw NoBuildFileException()
+  }
+
+  class NoBuildFileException(): Exception()
+}

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.contains
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.each
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.gradlePathRelativeTo
 import org.gradle.internal.scripts.ScriptingLanguages

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ intelliJPlatform = "2.5.0"
 kotlin = "2.1.20"
 kover = "0.9.1"
 qodana = "2024.3.4"
+moshi = "1.15.2"
 
 [libraries]
 junit-platform = { module = "org.junit:junit-bom", version.ref = "junit" }
@@ -23,6 +24,7 @@ autonomousapps-testkit-support = { module = "com.autonomousapps:gradle-testkit-s
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 lint-gradle = { module = "androidx.lint:lint-gradle", version.ref = "lint-gradle" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
+moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/spotlight-gradle-plugin/build.gradle
+++ b/spotlight-gradle-plugin/build.gradle
@@ -89,6 +89,7 @@ dependencies {
   lintChecks(libs.lint.gradle)
 
   functionalTestImplementation libs.truth
+  functionalTestImplementation libs.moshi
 
   testImplementation libs.assertk
   testImplementation platform(libs.junit.platform)

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
@@ -1,11 +1,7 @@
 package com.fueledbycaffeine.spotlight.functionaltest
 
 import com.autonomousapps.kit.truth.TestKitTruth.Companion.assertThat
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.SpiritboxProject
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.allProjects
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.ideProjects
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.includedProjects
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.sync
+import com.fueledbycaffeine.spotlight.functionaltest.fixtures.*
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/BuildResult.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/BuildResult.kt
@@ -1,6 +1,14 @@
 package com.fueledbycaffeine.spotlight.functionaltest.fixtures
 
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.gradle.testkit.runner.BuildResult
+import java.net.URI
+import java.nio.file.Path
+import kotlin.io.path.readLines
+import kotlin.io.path.toPath
 
 fun BuildResult.includedProjects(): List<String> {
   val includeProjectsLine = output.lines()
@@ -12,4 +20,76 @@ fun BuildResult.includedProjects(): List<String> {
       path
     }
     .toList()
+}
+
+private val CC_INVALIDATION_REASON = "configuration cache cannot be reused because (.*)".toRegex()
+private val CC_REPORT_REGEX = "See the complete report at (.*)".toRegex()
+private val BEGIN_CC_REPORT_JSON = "// begin-report-data"
+private val END_CC_REPORT_JSON = "// end-report-data"
+
+data class CCReport(
+  val diagnostics: List<CCDiagnostic>,
+  val totalProblemCount: Int,
+) {
+  val inputs: List<CCDiagnostic.Input> get() = diagnostics.map { it.input }
+}
+
+data class CCDiagnostic(
+  val trace: List<Trace>,
+  @Json(name = "input")
+  val inputJunk: List<InputInternal>,
+) {
+  data class Trace(
+    val kind: String,
+    val location: String = "unknown",
+  )
+
+  data class InputInternal(
+    @Json(name = "text")
+    val type: String?,
+    val name: String?,
+  )
+
+  data class Input(
+    val type: String,
+    val name: String,
+  )
+
+  val input = Input(
+    inputJunk.firstNotNullOf { it.type }.trim(),
+    inputJunk.firstNotNullOf { it.name }.trim(),
+  )
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+fun BuildResult.ccReport(): CCReport {
+  val match = output.lines().firstNotNullOf { CC_REPORT_REGEX.find(it, 0) }
+  val (reportUrl) = match.destructured
+  val reportPath = URI.create(reportUrl).toPath()
+
+  val ccInputsJson = reportPath.readLines().run {
+    get(indexOf(BEGIN_CC_REPORT_JSON) + 1)
+  }
+
+  val moshi = Moshi.Builder()
+    .addLast(KotlinJsonAdapterFactory())
+    .build()
+
+  val adapter = moshi.adapter<CCReport>()
+
+  return adapter.fromJson(ccInputsJson)!!
+}
+
+val BuildResult.configurationCacheReused: Boolean get() {
+  return output.lines().any { "Configuration cache entry reused" in it }
+}
+
+val BuildResult.configurationCacheStored: Boolean get() {
+  return output.lines().any { "Configuration cache entry stored" in it }
+}
+
+val BuildResult.configurationCacheInvalidationReason: String get() {
+  val match = output.lines().firstNotNullOf { CC_INVALIDATION_REASON.find(it) }
+  val (reason) = match.destructured
+  return reason
 }

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/GradleProject.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/GradleProject.kt
@@ -5,7 +5,7 @@ import com.autonomousapps.kit.GradleProject
 import org.gradle.testkit.runner.BuildResult
 
 fun GradleProject.build(vararg args: String): BuildResult =
-  GradleBuilder.build(rootDir, *args)
+  GradleBuilder.build(rootDir, *args, "--info")
 
 fun GradleProject.sync(vararg args: String): BuildResult =
-  GradleBuilder.build(rootDir, "help", "-Didea.sync.active=true", *args)
+  GradleBuilder.build(rootDir, "help", "--info", "-Didea.sync.active=true", *args)


### PR DESCRIPTION
Reduce the list of configuration cache inputs and add tests to verify exactly what inputs are being tracked.

before:

<img width="377" alt="image" src="https://github.com/user-attachments/assets/ffd0d0fe-40e6-43ee-9ca7-9883314ab6a2" />

after:

<img width="274" alt="image" src="https://github.com/user-attachments/assets/fc0c55ae-ce72-4170-9c5e-e5eaac4cb6d2" />
