### PR TITLE
Don't match strings as type-safe accessors

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFile.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFile.kt
@@ -13,7 +13,7 @@ public data class BuildFile(public val project: GradlePath) {
 }
 
 private val PROJECT_DEP_PATTERN = Regex("^(?:\\s+)?(\\w+)\\W+project\\([\"'](.*)[\"']\\)", MULTILINE)
-private val TYPESAFE_PROJECT_DEP_PATTERN = Regex("^(?!\\s*//).*?(?:^|\\W)(\\w+)?\\(?\\s*(projects\\.[\\w.]+)", MULTILINE)
+private val TYPESAFE_PROJECT_DEP_PATTERN = Regex("^(?!\\s*//)(?:(?![\"']).)*?(?:^|\\W)(\\w+)?\\(?\\s*(projects\\.[\\w.]+)", MULTILINE)
 private val CAMELCASE_REPLACE_PATTERN = Regex("(?<=.)[A-Z]")
 
 internal fun String.typeSafeAccessorAsDefaultGradlePath(): String {

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
@@ -245,6 +245,22 @@ class BuildFileTest {
       .containsExactlyInAnyOrder(typeSafeProject)
   }
 
+  @Test fun `ignores other DSL that can look like a type-safe project accessor`() {
+    val project = buildRoot.createProject(":foo")
+    val typeSafeProject = GradlePath(buildRoot, ":type-safe:project")
+    typeSafeProject.projectDir.createDirectories()
+    typeSafeProject.projectDir.resolve("build.gradle").createFile()
+    project.buildFilePath.writeText("""
+      android {
+        namespace = "com.example.projects.foo.bar"
+      }
+      """.trimIndent()
+    )
+    val buildFile = BuildFile(project)
+    val rule = TypeSafeProjectAccessorRule("spotlight", null)
+    assertThat(buildFile.parseDependencies(setOf(rule))).isEmpty()
+  }
+
   @Test fun `ignores type-safe project accessor's trailing path API`() {
     val project = buildRoot.createProject(":foo")
     val typeSafeProject = GradlePath(buildRoot, ":type-safe:project")


### PR DESCRIPTION
Prevent matching stuff like 

```groovy
android {
  namespace = 'com.example.projects.foo.bar'
}
```