### PR TITLE
Track `-p` directory in configuration cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 0.9
 * Add `SpotlightBuildService` to provide info about included projects to other build logic
 * Fix strings in buildscripts containing "projects." were being parsed as type-safe project accessors
-* Fix directory from `-p` Gradle flag being captured in configuration cache
+* Fix root directory being captured in configuration cache
 
 ### 0.8
 * Add a "strict" inference mode for type-safe project accessors

--- a/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/PathUtils.kt
+++ b/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/PathUtils.kt
@@ -1,0 +1,7 @@
+package com.gradle.scan.plugin.internal.com.fueledbycaffeine.spotlight.internal
+
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+
+internal fun Path.ccHiddenIsDirectory(vararg options: LinkOption): Boolean = Files.isDirectory(this, *options)


### PR DESCRIPTION
Because directory contents from `-p` are weren't captured in CC previously, there was no way to invalidate CC when adding/removing a project in that sub-hierarchy. 