### PR TITLE
Add targetsOverride option to DSL

### DIFF
--- a/spotlight-gradle-plugin/api/spotlight-gradle-plugin.api
+++ b/spotlight-gradle-plugin/api/spotlight-gradle-plugin.api
@@ -37,6 +37,7 @@ public abstract class com/fueledbycaffeine/spotlight/dsl/SpotlightExtension {
 	public static final field NAME Ljava/lang/String;
 	public fun <init> (Lorg/gradle/api/file/BuildLayout;Lorg/gradle/api/model/ObjectFactory;)V
 	public static final fun getSpotlightExtension (Lorg/gradle/api/plugins/ExtensionContainer;)Lcom/fueledbycaffeine/spotlight/dsl/SpotlightExtension;
+	public final fun getTargetsOverride ()Lorg/gradle/api/provider/Property;
 	public final fun getTypeSafeAccessorInference ()Lorg/gradle/api/provider/Property;
 	public final fun whenBuildscriptMatches (Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public final fun whenProjectPathMatches (Ljava/lang/String;Lorg/gradle/api/Action;)V

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
@@ -1,7 +1,8 @@
 package com.fueledbycaffeine.spotlight.dsl
 
 import com.fueledbycaffeine.spotlight.SpotlightSettingsPlugin
-import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.ALL_PROJECTS_LOCATION
+import com.fueledbycaffeine.spotlight.buildscript.GradlePath
+import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.IDE_PROJECTS_LOCATION
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.BuildscriptMatchRule
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.ProjectPathMatchRule
@@ -10,7 +11,9 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.file.BuildLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.intellij.lang.annotations.Language
 import javax.inject.Inject
 
@@ -19,7 +22,7 @@ import javax.inject.Inject
  */
 @Suppress("UnstableApiUsage")
 public abstract class SpotlightExtension @Inject constructor(
-  layout: BuildLayout,
+  private val layout: BuildLayout,
   objects: ObjectFactory,
 ) {
   public companion object {
@@ -44,6 +47,25 @@ public abstract class SpotlightExtension @Inject constructor(
    */
   public val typeSafeAccessorInference: Property<TypeSafeAccessorInference> =
     objects.property(TypeSafeAccessorInference::class.java).convention(TypeSafeAccessorInference.STRICT)
+
+  /**
+   * Override the inferred target projects or projects from [IDE_PROJECTS_LOCATION].
+   *
+   * The value should be a provider where the value is a comma or newline separated list of Gradle project paths.
+   *
+   * This is useful for gradle-profiler scenarios where generating the IDE target projects list is not possible or for
+   * running a task on a specific subset of projects without fully specifying the task path of each task.
+   *
+   * ```
+   * def targetProjects = providers.gradleProperty("target-projects")
+   *
+   * spotlight {
+   *   targetsOverride = targetProjects
+   * }
+   * ```
+   */
+  public val targetsOverride: Property<String> =
+    objects.property(String::class.java).unsetConvention()
 
   /**
    * Add an implicit dependencies rule to include certain projects when the contents of the buildscript matches [pattern]
@@ -82,5 +104,13 @@ public abstract class SpotlightExtension @Inject constructor(
     buildSet {
       addAll(buildscriptMatchRules.map { BuildscriptMatchRule(it.pattern, it.includes.get()) })
       addAll(projectPathMatchRules.map { ProjectPathMatchRule(it.pattern, it.includes.get()) })
+    }
+
+  internal val targetPathsOverride: Set<GradlePath>?
+    get() = when (targetsOverride.isPresent) {
+      true -> targetsOverride.get().split(",\n")
+        .map { GradlePath(layout.rootDirectory.asFile, it.trim()) }
+        .toSet()
+      else -> null
     }
 }


### PR DESCRIPTION
Override the inferred target projects or projects from`gradle/ide-projects.txt`.

The value should be a provider where the value is a comma or newline separated list of Gradle project paths.

This is useful for gradle-profiler scenarios where generating the IDE target projects list is not possible or for
running a task on a specific subset of projects without fully specifying the task path of each task.

```
def targetProjects = providers.gradleProperty("target-projects")
spotlight {
  targetsOverride = targetProjects
}
```