### PR TITLE
Fix issues with typesafe accessor behavior in strict mode

### DIFF
--- a/buildscript-utils/api/buildscript-utils.api
+++ b/buildscript-utils/api/buildscript-utils.api
@@ -115,6 +115,19 @@ public final class com/fueledbycaffeine/spotlight/buildscript/graph/Edge {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/fueledbycaffeine/spotlight/buildscript/graph/FullModeTypeSafeProjectAccessorRule : com/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/FullModeTypeSafeProjectAccessorRule;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/graph/FullModeTypeSafeProjectAccessorRule;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/FullModeTypeSafeProjectAccessorRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRootProjectAccessor ()Ljava/lang/String;
+	public final fun getTypeSafeAccessorMap ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/fueledbycaffeine/spotlight/buildscript/graph/Graph {
 	public fun <init> ()V
 	public final fun accessorsOf (Lcom/fueledbycaffeine/spotlight/buildscript/graph/GraphNode;)Ljava/util/Set;
@@ -157,17 +170,18 @@ public final class com/fueledbycaffeine/spotlight/buildscript/graph/ImplicitDepe
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule : com/fueledbycaffeine/spotlight/buildscript/graph/DependencyRule {
-	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class com/fueledbycaffeine/spotlight/buildscript/graph/StrictModeTypeSafeProjectAccessorRule : com/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule {
+	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule;
-	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule;
+	public final fun copy (Ljava/lang/String;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/StrictModeTypeSafeProjectAccessorRule;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/graph/StrictModeTypeSafeProjectAccessorRule;Ljava/lang/String;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/graph/StrictModeTypeSafeProjectAccessorRule;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getRootProjectAccessor ()Ljava/lang/String;
-	public final fun getTypeSafeAccessorMap ()Ljava/util/Map;
+	public fun getRootProjectAccessor ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule : com/fueledbycaffeine/spotlight/buildscript/graph/DependencyRule {
+	public abstract fun getRootProjectAccessor ()Ljava/lang/String;
 }
 

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/ImplicitDependencyRule.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/ImplicitDependencyRule.kt
@@ -4,7 +4,7 @@ import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.squareup.moshi.JsonClass
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
 
-public interface DependencyRule
+public sealed interface DependencyRule
 
 @JsonClass(generateAdapter = false, generator = "sealed:type")
 public sealed interface ImplicitDependencyRule : DependencyRule {
@@ -27,12 +27,29 @@ public sealed interface ImplicitDependencyRule : DependencyRule {
   }
 }
 
-public data class TypeSafeProjectAccessorRule(
+public sealed interface TypeSafeProjectAccessorRule : DependencyRule {
   /**
-   * Gradle generates an accessor for the root project based on the root project name. Projects in the build are also
-   * accessible via this accessor. For example `projects.buildscriptUtils` and `projects.spotlight.buildscriptUtils`
-   * are both valid for a project named "spotlight".
+   * Gradle generates an accessor for the root project based on the root project name. Projects in
+   * the build are also accessible via this accessor. For example `projects.buildscriptUtils` and
+   * `projects.spotlight.buildscriptUtils` are both valid for a project named "spotlight".
    */
-  val rootProjectAccessor: String,
-  val typeSafeAccessorMap: Map<String, GradlePath>? = null,
-) : DependencyRule
+  public val rootProjectAccessor: String
+}
+
+/**
+ * Makes no assumptions about project path naming.
+ */
+public data class FullModeTypeSafeProjectAccessorRule(
+  override val rootProjectAccessor: String,
+  /**
+   * Specifies the mapping of accessor name to the gradle path.
+   */
+  val typeSafeAccessorMap: Map<String, GradlePath>,
+) : TypeSafeProjectAccessorRule
+
+/**
+ * Assumes that project paths are lowercase and kebab-case
+ */
+public data class StrictModeTypeSafeProjectAccessorRule(
+  override val rootProjectAccessor: String,
+) : TypeSafeProjectAccessorRule

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -5,6 +5,8 @@ import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightRulesList
 import com.fueledbycaffeine.spotlight.buildscript.gradlePathRelativeTo
 import com.fueledbycaffeine.spotlight.buildscript.graph.BreadthFirstSearch
+import com.fueledbycaffeine.spotlight.buildscript.graph.FullModeTypeSafeProjectAccessorRule
+import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjectAccessorRule
 import com.fueledbycaffeine.spotlight.buildscript.graph.TypeSafeProjectAccessorRule
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension.Companion.getSpotlightExtension
@@ -108,13 +110,13 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
     logger.info("Spotlight type-safe project accessor inference is {}", typeSafeInferenceLevel)
 
     val rules = if (typeSafeInferenceLevel != TypeSafeAccessorInference.DISABLED) {
-      val typeSafeProjectAccessorMap = if (typeSafeInferenceLevel == TypeSafeAccessorInference.FULL) {
-        getAllProjects().associateBy { it.typeSafeAccessorName }
-      } else {
-        emptyMap()
-      }
       val rootProjectTypeSafeAccessor = GradlePath(rootDir.toPath(), settings.rootProject.name).typeSafeAccessorName
-      val typeSafeAccessorRule = TypeSafeProjectAccessorRule(rootProjectTypeSafeAccessor, typeSafeProjectAccessorMap)
+      val typeSafeAccessorRule = if (typeSafeInferenceLevel == TypeSafeAccessorInference.FULL) {
+        val mapping = getAllProjects().associateBy { it.typeSafeAccessorName }
+        FullModeTypeSafeProjectAccessorRule(rootProjectTypeSafeAccessor, mapping)
+      } else {
+        StrictModeTypeSafeProjectAccessorRule(rootProjectTypeSafeAccessor)
+      }
       getSpotlightRules() + typeSafeAccessorRule
     } else {
       getSpotlightRules()


### PR DESCRIPTION
Plugin was supplying `mapOf()` to the rule when `STRICT` mode (the default) was used, which actually implies `FULL` mode to the buildscript-utils code, and then never matches any type-safe accessors because there is nothing to match. The value passed should have been `null`.

Solved this by splitting the rule in two, one class for each mode.