### PR TITLE
Make targetsOverride handle empty strings

### DIFF
--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -331,6 +331,67 @@ class SpotlightBuildFunctionalTest {
   }
 
   @Test
+  fun `empty target overrides runs all projects`() {
+    // Given
+    val project = SpiritboxProject().build()
+    val settings = project.rootDir.resolve("settings.gradle")
+    settings.appendText(
+      """
+      def targetProjects = providers.gradleProperty("target-projects")
+      spotlight {
+        targetsOverride = targetProjects
+      }
+    """.trimIndent()
+    )
+
+    // When
+    val result = project.build("assemble", "-Ptarget-projects=")
+
+    // Then
+    assertThat(result).task(":rotoscope:assemble").succeeded()
+    val includedProjects = result.includedProjects()
+    val expectedProjects = listOf(
+      project.rootProject.settingsScript.rootProjectName,
+      ":eternal-blue",
+      ":rotoscope",
+      ":the-fear-of-fear",
+      ":tsunami-sea",
+      ":eternal-blue:circle-with-me",
+      ":eternal-blue:constance",
+      ":eternal-blue:eternal-blue",
+      ":eternal-blue:halcyon",
+      ":eternal-blue:holy-roller",
+      ":eternal-blue:hurt-you",
+      ":eternal-blue:secret-garden",
+      ":eternal-blue:silk-in-the-strings",
+      ":eternal-blue:sun-killer",
+      ":eternal-blue:the-summit",
+      ":eternal-blue:we-live-in-a-strange-world",
+      ":eternal-blue:yellowjacket",
+      ":rotoscope:hysteria",
+      ":rotoscope:rotoscope",
+      ":rotoscope:sew-me-up",
+      ":the-fear-of-fear:angel-eyes",
+      ":the-fear-of-fear:cellar-door",
+      ":the-fear-of-fear:jaded",
+      ":the-fear-of-fear:the-void",
+      ":the-fear-of-fear:too-close-too-late",
+      ":the-fear-of-fear:ultraviolet",
+    )
+    assertThat(includedProjects).containsExactlyElementsIn(expectedProjects)
+    val ccReport = result.ccReport()
+
+    assertThat(ccReport.inputs).containsExactlyElementsIn(
+      listOf(
+        CCDiagnostic.Input(type = "system property", name = "spotlight.enabled"),
+        CCDiagnostic.Input(type = "system property", name = "idea.sync.active"),
+        CCDiagnostic.Input(type = "file system entry", name = "gradle/all-projects.txt"),
+        CCDiagnostic.Input(type = "file", name = "gradle/all-projects.txt"),
+      )
+    )
+  }
+
+  @Test
   fun `invalidates configuration cache when adding a project to directory`() {
     // Given
     val project = SpiritboxProject().build()

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -50,7 +50,7 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
 
   private fun Settings.setupSpotlight() {
     val projectsOverride = options.targetPathsOverride
-    val projects = if (projectsOverride != null) {
+    val projects = if (projectsOverride.isNotEmpty()) {
       logger.info("spotlight.targetsOverride contains {} targets", projectsOverride.size)
       implicitAndTransitiveDependenciesOf(projectsOverride)
     } else {

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
@@ -4,10 +4,10 @@ import com.fueledbycaffeine.spotlight.SpotlightSettingsPlugin
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.IDE_PROJECTS_LOCATION
 import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.file.BuildLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.Property
-import org.gradle.api.file.BuildLayout
 import javax.inject.Inject
 
 /**
@@ -49,7 +49,7 @@ public abstract class SpotlightExtension @Inject constructor(
    * This is useful for gradle-profiler scenarios where generating the IDE target projects list is not possible or for
    * running a task on a specific subset of projects without fully specifying the task path of each task.
    *
-   * ```
+   * ``` kotlin
    * def targetProjects = providers.gradleProperty("target-projects")
    *
    * spotlight {
@@ -60,11 +60,10 @@ public abstract class SpotlightExtension @Inject constructor(
   public val targetsOverride: Property<String> =
     objects.property(String::class.java).unsetConvention()
 
-  internal val targetPathsOverride: Set<GradlePath>?
-    get() = when (targetsOverride.isPresent) {
-      true -> targetsOverride.get().split(",\n")
-        .map { GradlePath(layout.rootDirectory.asFile, it.trim()) }
-        .toSet()
-      else -> null
-    }
+  internal val targetPathsOverride: Set<GradlePath>
+    get() = targetsOverride.getOrElse("").orEmpty()
+      .split(",", System.lineSeparator())
+      .filterNot { it.isEmpty() }
+      .map { GradlePath(layout.rootDirectory.asFile, it.trim()) }
+      .toSet()
 }


### PR DESCRIPTION
You can now provide an empty string and it will act as if the value has not been set.