### PR TITLE
Excludes unused projects in the IDE

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
@@ -146,3 +146,25 @@ public fun Path.gradlePathRelativeTo(buildRoot: Path): GradlePath {
 private fun String.capitalize(): String = replaceFirstChar {
   if (it.isLowerCase()) it.titlecase(getDefault()) else it.toString()
 }
+
+/**
+ * Minimize the set of project paths to exclude by filtering out any that are prefixed by another path.
+ */
+public fun Collection<GradlePath>.minimize(): Set<GradlePath> {
+  if (size < 2) return toSet()
+  val sorted = sortedBy { it.path }
+  if (sorted[0].path == ":") {
+    // Root project consumes all
+    return setOf(sorted[0])
+  }
+  return sortedBy { it.path }
+    .fold(LinkedHashSet()) { acc, path ->
+      val last = acc.lastOrNull()
+      if (last != null && path.path.startsWith("${last.path}:")) {
+        acc
+      } else {
+        acc.add(path)
+        acc
+      }
+    }
+}

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/direxclude/SpotlightExcludeDirectoryPolicy.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/direxclude/SpotlightExcludeDirectoryPolicy.kt
@@ -1,0 +1,29 @@
+package com.fueledbycaffeine.spotlight.idea.direxclude
+
+import com.fueledbycaffeine.spotlight.buildscript.minimize
+import com.fueledbycaffeine.spotlight.idea.SpotlightProjectService
+import com.intellij.openapi.components.serviceOrNull
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.impl.DirectoryIndexExcludePolicy
+import com.intellij.openapi.vfs.VfsUtilCore
+import kotlin.io.path.absolutePathString
+
+class SpotlightExcludeDirectoryPolicy(private val project: Project) : DirectoryIndexExcludePolicy {
+  override fun getExcludeUrlsForProject(): Array<String> {
+    val service = project.serviceOrNull<SpotlightProjectService>() ?: return emptyArray()
+    val allProjects = service.allProjects.value
+    if (allProjects.isEmpty()) return emptyArray()
+    val ideProjects = service.ideProjects.value
+    if (ideProjects.isEmpty()) return emptyArray()
+
+    // Non-indexed projects are allProjects - ideProjects
+    val excludedProjects = (allProjects - ideProjects).minimize()
+
+    return excludedProjects
+      .map {
+        val path = it.projectDir.absolutePathString()
+        VfsUtilCore.pathToUrl(path)
+      }
+      .toTypedArray()
+  }
+}

--- a/spotlight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/spotlight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@ For use with the <a href="https://plugins.gradle.org/plugin/com.fueledbycaffeine
     <editorNotificationProvider implementation="com.fueledbycaffeine.spotlight.idea.notification.ProjectStaleNotificationProvider"/>
     <statusBarWidgetFactory implementation="com.fueledbycaffeine.spotlight.idea.ui.SpotlightStatusBarWidgetFactory"
                             id="com.fueledbycaffeine.spotlight"/>
+    <directoryIndexExcludePolicy
+            implementation="com.fueledbycaffeine.spotlight.idea.direxclude.SpotlightExcludeDirectoryPolicy"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
Note this doesn't fully work yet due to this only checking raw ide-projects.txt and not their transitives, which I'll look at in a separate PR