### PR TITLE
Add runLocalIde helper for local IDE testing

### DIFF
--- a/spotlight-idea-plugin/build.gradle
+++ b/spotlight-idea-plugin/build.gradle
@@ -19,6 +19,14 @@ dependencies {
     intellijIdeaCommunity("2025.1.3")
 
     bundledPlugin("com.intellij.gradle")
+
+    intellijPlatformTesting.runIde.register("runLocalIde") {
+      // https://plugins.jetbrains.com/docs/intellij/android-studio.html#configuring-the-plugin-gradle-build-script
+      def path = providers.gradleProperty("intellijPlatformTesting.idePath").getOrNull()
+      if (path != null) {
+        localPath.set(file(it))
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This is something we did in our plugin to allow specifying a custom local IDE to easily test with that installation instead