### PR TITLE
Load all recursive projects in IDE + track rules

### DIFF
--- a/buildscript-utils/api/buildscript-utils.api
+++ b/buildscript-utils/api/buildscript-utils.api
@@ -205,19 +205,22 @@ public abstract interface class com/fueledbycaffeine/spotlight/buildscript/graph
 }
 
 public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules {
+	public static final field Companion Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Set;
-	public final fun component3 ()Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
-	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
-	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public fun <init> (Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)V
+	public synthetic fun <init> (Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public final fun copy (Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getImplicitRules ()Ljava/util/Set;
-	public final fun getProjectName ()Ljava/lang/String;
 	public final fun getTypeSafeAccessorInference ()Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules$Companion {
+	public final fun getEMPTY ()Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
 }
 

--- a/buildscript-utils/api/buildscript-utils.api
+++ b/buildscript-utils/api/buildscript-utils.api
@@ -90,10 +90,24 @@ public final class com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList
 	public static final field Companion Lcom/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList$Companion;
 	public static final field SPOTLIGHT_RULES_LOCATION Ljava/lang/String;
 	public fun <init> (Ljava/nio/file/Path;)V
-	public final fun read ()Ljava/util/Set;
+	public final fun read ()Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
 }
 
 public final class com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList$Companion {
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListKt {
+	public static final fun computeSpotlightRules (Ljava/nio/file/Path;Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;Lkotlin/jvm/functions/Function0;)Ljava/util/Set;
+	public static synthetic fun computeSpotlightRules$default (Ljava/nio/file/Path;Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/util/Set;
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference : java/lang/Enum {
+	public static final field DISABLED Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public static final field FULL Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public static final field STRICT Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public static fun values ()[Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
 }
 
 public final class com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearch {
@@ -188,5 +202,22 @@ public final class com/fueledbycaffeine/spotlight/buildscript/graph/StrictModeTy
 
 public abstract interface class com/fueledbycaffeine/spotlight/buildscript/graph/TypeSafeProjectAccessorRule : com/fueledbycaffeine/spotlight/buildscript/graph/DependencyRule {
 	public abstract fun getRootProjectAccessor ()Ljava/lang/String;
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;Ljava/lang/String;Ljava/util/Set;Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getImplicitRules ()Ljava/util/Set;
+	public final fun getProjectName ()Ljava/lang/String;
+	public final fun getTypeSafeAccessorInference ()Lcom/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/buildscript-utils/build.gradle
+++ b/buildscript-utils/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   api(libs.moshix.sealedRuntime)
   implementation(libs.moshi.kotlin)
   implementation(libs.moshix.sealedReflect)
+  implementation(libs.okio)
 
   testImplementation gradleApi()
   testImplementation libs.assertk

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList.kt
@@ -31,7 +31,7 @@ public class SpotlightRulesList(private val root: Path) {
         JsonReader.of(rulesPath.source().buffer()).use { reader ->
           reader.peekJson().use { reader ->
             try {
-              rulesAdapter.fromJson(reader) ?: SpotlightRules()
+              rulesAdapter.fromJson(reader) ?: SpotlightRules.EMPTY
             } catch (_: JsonDataException) {
               // Try just parsing it as a set of rules (legacy)
               val ruleSet = ruleSetAdapter.fromJson(reader) ?: emptySet()
@@ -43,7 +43,7 @@ public class SpotlightRulesList(private val root: Path) {
         throw InvalidSpotlightRules("Spotlight rules at $SPOTLIGHT_RULES_LOCATION were invalid", e)
       }
     } else {
-      SpotlightRules()
+      SpotlightRules.EMPTY
     }
   }
 

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesList.kt
@@ -4,13 +4,13 @@ import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
-import com.squareup.moshi.Types.newParameterizedType
+import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.reflect.MoshiSealedJsonAdapterFactory
-import okio.IOException
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readText
+import okio.IOException
 
 public class SpotlightRulesList(private val root: Path) {
   public companion object {
@@ -18,12 +18,10 @@ public class SpotlightRulesList(private val root: Path) {
   }
 
   public fun read(): Set<ImplicitDependencyRule> {
-    val type = newParameterizedType(Set::class.java, ImplicitDependencyRule::class.java)
-    val adapter = moshi.adapter<Set<ImplicitDependencyRule>>(type)
     val rulesPath = root.resolve(SPOTLIGHT_RULES_LOCATION)
     return if (rulesPath.exists()) {
       try {
-        adapter.fromJson(rulesPath.readText()) ?: emptySet()
+        ruleSetAdapter.fromJson(rulesPath.readText()) ?: emptySet()
       } catch (e: IOException) {
         throw InvalidSpotlightRules("Spotlight rules at $SPOTLIGHT_RULES_LOCATION were invalid", e)
       }
@@ -39,6 +37,9 @@ public class SpotlightRulesList(private val root: Path) {
       .addLast(KotlinJsonAdapterFactory())
       .build()
   }
+
+  @OptIn(ExperimentalStdlibApi::class) // Not actually experimental anymore!
+  private val ruleSetAdapter = moshi.adapter<Set<ImplicitDependencyRule>>()
 }
 
 public class InvalidSpotlightRules(message: String, cause: Throwable) : Exception(message, cause)

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/TypeSafeAccessorInference.kt
@@ -1,6 +1,4 @@
-package com.fueledbycaffeine.spotlight.dsl
-
-import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.ALL_PROJECTS_LOCATION
+package com.fueledbycaffeine.spotlight.buildscript
 
 public enum class TypeSafeAccessorInference {
   /**
@@ -16,7 +14,7 @@ public enum class TypeSafeAccessorInference {
   /**
    * Enables full processing of type-safe project accessors, with no limitations on path names.
    *
-   * Note that this causes [ALL_PROJECTS_LOCATION] to be captured in the configuration cache because this file must be
+   * Note that this causes [SpotlightProjectList.ALL_PROJECTS_LOCATION] to be captured in the configuration cache because this file must be
    * read to fully compute the mapping of type-safe project accessor names to Gradle project paths.
    */
   FULL,

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearch.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearch.kt
@@ -11,13 +11,10 @@ public object BreadthFirstSearch {
     // In lieu of a flattenTo() option, this creates an intermediate
     // set to avoid the intermediate list + distinct()
     return buildSet(INITIAL_CAPACITY) {
-      val seen = LinkedHashSet<T>(INITIAL_CAPACITY)
+      // Include the initial nodes in the result
+      addAll(nodes)
       for (values in deps.values) {
-        for (dep in values) {
-          if (seen.add(dep)) {
-            add(dep)
-          }
-        }
+        addAll(values)
       }
     }
   }

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
@@ -6,4 +6,8 @@ import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
 public data class SpotlightRules(
   val implicitRules: Set<ImplicitDependencyRule> = emptySet(),
   val typeSafeAccessorInference: TypeSafeAccessorInference? = null,
-)
+) {
+  public companion object {
+    public val EMPTY: SpotlightRules = SpotlightRules()
+  }
+}

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
@@ -4,7 +4,6 @@ import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
 
 public data class SpotlightRules(
-  val projectName: String? = null,
   val implicitRules: Set<ImplicitDependencyRule> = emptySet(),
   val typeSafeAccessorInference: TypeSafeAccessorInference? = null,
 )

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
@@ -1,0 +1,9 @@
+package com.fueledbycaffeine.spotlight.buildscript.models
+
+import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
+import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
+
+public data class SpotlightRules(
+  val implicitRules: Set<ImplicitDependencyRule> = emptySet(),
+  val typeSafeAccessorInference: TypeSafeAccessorInference? = TypeSafeAccessorInference.DISABLED,
+)

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
@@ -4,6 +4,7 @@ import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule
 
 public data class SpotlightRules(
+  val projectName: String? = null,
   val implicitRules: Set<ImplicitDependencyRule> = emptySet(),
-  val typeSafeAccessorInference: TypeSafeAccessorInference? = TypeSafeAccessorInference.DISABLED,
+  val typeSafeAccessorInference: TypeSafeAccessorInference? = null,
 )

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectListTest.kt
@@ -1,17 +1,15 @@
 package com.fueledbycaffeine.spotlight.buildscript
 
-import assertk.all
 import assertk.assertThat
-import assertk.assertions.*
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.io.TempDir
-import java.io.FileNotFoundException
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 
 class SpotlightProjectListTest {
   @TempDir

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
@@ -1,19 +1,19 @@
 package com.fueledbycaffeine.spotlight.buildscript
 
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
-import java.nio.file.Path
-import kotlin.io.path.writeText
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.*
-import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjectAccessorRule
-import org.junit.jupiter.api.assertThrows
+import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.BuildscriptMatchRule
+import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.ProjectPathMatchRule
+import java.nio.file.Path
 import kotlin.io.path.createFile
 import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
 
 class SpotlightRulesListTest {
   @TempDir

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
@@ -8,6 +8,7 @@ import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.*
 import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjectAccessorRule
 import org.junit.jupiter.api.assertThrows
@@ -43,6 +44,8 @@ class SpotlightRulesListTest {
       ProjectPathMatchRule(":foo", setOf(GradlePath(tempDir, ":bar"))),
       BuildscriptMatchRule("example", setOf(GradlePath(tempDir, ":foo"))),
     )
+    assertThat(rules.projectName).isNull()
+    assertThat(rules.typeSafeAccessorInference).isNull()
   }
 
   @Test
@@ -52,6 +55,7 @@ class SpotlightRulesListTest {
     rulesFile.writeText(
       """
       {
+        "projectName": "example-project",
         "implicitRules": [
           {
             "type": "project-path-match-rule",
@@ -69,6 +73,7 @@ class SpotlightRulesListTest {
       """.trimIndent()
     )
     val rules = SpotlightRulesList(tempDir).read()
+    assertThat(rules.projectName).isEqualTo("example-project")
     assertThat(rules.implicitRules).containsExactlyInAnyOrder(
       ProjectPathMatchRule(":foo", setOf(GradlePath(tempDir, ":bar"))),
       BuildscriptMatchRule("example", setOf(GradlePath(tempDir, ":foo"))),

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
@@ -44,7 +44,6 @@ class SpotlightRulesListTest {
       ProjectPathMatchRule(":foo", setOf(GradlePath(tempDir, ":bar"))),
       BuildscriptMatchRule("example", setOf(GradlePath(tempDir, ":foo"))),
     )
-    assertThat(rules.projectName).isNull()
     assertThat(rules.typeSafeAccessorInference).isNull()
   }
 
@@ -55,7 +54,6 @@ class SpotlightRulesListTest {
     rulesFile.writeText(
       """
       {
-        "projectName": "example-project",
         "implicitRules": [
           {
             "type": "project-path-match-rule",
@@ -73,7 +71,6 @@ class SpotlightRulesListTest {
       """.trimIndent()
     )
     val rules = SpotlightRulesList(tempDir).read()
-    assertThat(rules.projectName).isEqualTo("example-project")
     assertThat(rules.implicitRules).containsExactlyInAnyOrder(
       ProjectPathMatchRule(":foo", setOf(GradlePath(tempDir, ":bar"))),
       BuildscriptMatchRule("example", setOf(GradlePath(tempDir, ":foo"))),

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearchTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/BreadthFirstSearchTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
 import org.junit.jupiter.api.Test
 
-private class TestNode(val successors: Set<TestNode>): GraphNode<TestNode> {
+private class TestNode(val successors: Set<TestNode>) : GraphNode<TestNode> {
   override fun findSuccessors(rules: Set<DependencyRule>): Set<TestNode> = successors
 }
 
@@ -18,10 +18,27 @@ class BreadthFirstSearchTest {
     val allChildren = BreadthFirstSearch.flatten(setOf(rootNode))
 
     assertThat(allChildren).containsExactlyInAnyOrder(
+      rootNode,
       child1,
       child2,
       grandchild1,
       grandchild2,
+    )
+  }
+
+  @Test fun `includes initial nodes in flattened result`() {
+    val leaf1 = TestNode(setOf())
+    val leaf2 = TestNode(setOf())
+    val parent1 = TestNode(setOf(leaf1))
+    val parent2 = TestNode(setOf(leaf2))
+
+    val result = BreadthFirstSearch.flatten(setOf(parent1, parent2))
+
+    assertThat(result).containsExactlyInAnyOrder(
+      parent1,
+      parent2,
+      leaf1,
+      leaf2,
     )
   }
 }

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
@@ -1,20 +1,24 @@
 package com.fueledbycaffeine.spotlight.buildscript.graph
 
 import assertk.assertThat
-import assertk.assertions.*
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.gradlePathRelativeTo
+import java.io.FileNotFoundException
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.writeText
 import org.gradle.internal.scripts.ScriptingLanguages
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import java.io.FileNotFoundException
-import java.nio.file.Path
-import kotlin.io.path.createDirectories
-import kotlin.io.path.createFile
-import kotlin.io.path.writeText
 
 class GradlePathTest {
   @TempDir lateinit var buildRoot: Path

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
@@ -2,6 +2,8 @@ package com.fueledbycaffeine.spotlight.buildscript.graph
 
 import assertk.assertThat
 import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,3 +20,4 @@ moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshix-sealedReflect = { module = "dev.zacsweers.moshix:moshi-sealed-reflect", version.ref = "moshix" }
 moshix-sealedRuntime = { module = "dev.zacsweers.moshix:moshi-sealed-runtime", version.ref = "moshix" }
+okio = "com.squareup.okio:okio:3.7.0"

--- a/spotlight-gradle-plugin/api/spotlight-gradle-plugin.api
+++ b/spotlight-gradle-plugin/api/spotlight-gradle-plugin.api
@@ -38,15 +38,6 @@ public final class com/fueledbycaffeine/spotlight/dsl/SpotlightExtension$Compani
 	public final fun getSpotlightExtension (Lorg/gradle/api/plugins/ExtensionContainer;)Lcom/fueledbycaffeine/spotlight/dsl/SpotlightExtension;
 }
 
-public final class com/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference : java/lang/Enum {
-	public static final field DISABLED Lcom/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference;
-	public static final field FULL Lcom/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference;
-	public static final field STRICT Lcom/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference;
-	public static fun values ()[Lcom/fueledbycaffeine/spotlight/dsl/TypeSafeAccessorInference;
-}
-
 public final class com/fueledbycaffeine/spotlight/utils/SpotlightProperties {
 	public static final fun isSpotlightEnabled (Lorg/gradle/api/initialization/Settings;)Z
 }

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -204,7 +204,7 @@ class SpotlightBuildFunctionalTest {
 
     // Then
     assertThat(result).task(":help").succeeded()
-    assertThat(result).output().contains("Requested targets include 0 projects transitively")
+    assertThat(result).output().contains("Requested targets include 1 projects transitively")
     val includedProjects = result.includedProjects()
     assertThat(includedProjects).containsExactly(project.rootProject.settingsScript.rootProjectName)
     val ccReport = result.ccReport()

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -190,6 +190,7 @@ class SpotlightBuildFunctionalTest {
       CCDiagnostic.Input(type="system property", name="spotlight.enabled"),
       CCDiagnostic.Input(type="system property", name="idea.sync.active"),
       CCDiagnostic.Input(type="file system entry", name="gradle/spotlight-rules.json"),
+      CCDiagnostic.Input(type="file", name="gradle/spotlight-rules.json"),
     ))
   }
 

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -204,7 +204,7 @@ class SpotlightBuildFunctionalTest {
 
     // Then
     assertThat(result).task(":help").succeeded()
-    assertThat(result).output().contains("Requested targets include 1 projects transitively")
+    assertThat(result).output().contains("Requested targets include 0 projects transitively")
     val includedProjects = result.includedProjects()
     assertThat(includedProjects).containsExactly(project.rootProject.settingsScript.rootProjectName)
     val ccReport = result.ccReport()

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -135,6 +135,7 @@ class SpotlightBuildFunctionalTest {
       CCDiagnostic.Input(type="system property", name="spotlight.enabled"),
       CCDiagnostic.Input(type="system property", name="idea.sync.active"),
       CCDiagnostic.Input(type="file system entry", name="gradle/spotlight-rules.json"),
+      CCDiagnostic.Input(type="file", name="gradle/spotlight-rules.json"),
     ))
   }
 

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -10,7 +10,7 @@ import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjec
 import com.fueledbycaffeine.spotlight.buildscript.graph.TypeSafeProjectAccessorRule
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension.Companion.getSpotlightExtension
-import com.fueledbycaffeine.spotlight.dsl.TypeSafeAccessorInference
+import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
 import com.fueledbycaffeine.spotlight.utils.guessProjectsFromTaskRequests
 import com.fueledbycaffeine.spotlight.utils.include
 import com.fueledbycaffeine.spotlight.utils.isIdeSync

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -3,25 +3,21 @@ package com.fueledbycaffeine.spotlight
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightRulesList
+import com.fueledbycaffeine.spotlight.buildscript.computeSpotlightRules
 import com.fueledbycaffeine.spotlight.buildscript.gradlePathRelativeTo
 import com.fueledbycaffeine.spotlight.buildscript.graph.BreadthFirstSearch
-import com.fueledbycaffeine.spotlight.buildscript.graph.FullModeTypeSafeProjectAccessorRule
-import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjectAccessorRule
-import com.fueledbycaffeine.spotlight.buildscript.graph.TypeSafeProjectAccessorRule
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension
 import com.fueledbycaffeine.spotlight.dsl.SpotlightExtension.Companion.getSpotlightExtension
-import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
-import com.fueledbycaffeine.spotlight.buildscript.computeSpotlightRules
 import com.fueledbycaffeine.spotlight.utils.guessProjectsFromTaskRequests
 import com.fueledbycaffeine.spotlight.utils.include
 import com.fueledbycaffeine.spotlight.utils.isIdeSync
 import com.fueledbycaffeine.spotlight.utils.isSpotlightEnabled
+import java.io.FileNotFoundException
+import kotlin.time.measureTimedValue
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import java.io.FileNotFoundException
-import kotlin.time.measureTimedValue
 
 private val logger: Logger = Logging.getLogger(SpotlightSettingsPlugin::class.java)
 

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -109,11 +109,10 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
     val projectName = settings.rootProject.name
     val rules = computeSpotlightRules(rootDir.toPath(), projectName, implicitRules, typeSafeInferenceLevel) { getAllProjects() }
 
-    val bfsResults = measureTimedValue { BreadthFirstSearch.flatten(targets, rules) }
-    logger.info("BFS search of project graph took {}ms", bfsResults.duration.inWholeMilliseconds)
-    val transitives = bfsResults.value
-    logger.info("Requested targets include {} projects transitively", transitives.size)
-    return targets + transitives
+    val (targetsAndTransitives, duration) = measureTimedValue { BreadthFirstSearch.flatten(targets, rules) }
+    logger.info("BFS search of project graph took {}ms", duration.inWholeMilliseconds)
+    logger.info("Requested targets include {} projects transitively", targetsAndTransitives.size - targets.size)
+    return targetsAndTransitives
   }
 
   private fun Settings.getAllProjects() = SpotlightProjectList.allProjects(settingsDir.toPath()).read()

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
@@ -35,7 +35,7 @@ public abstract class SpotlightExtension @Inject constructor(
   /**
    * Sets the level of processing to be done to support type-safe project accessors.
    *
-   * Defaults to [com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference.STRICT]
+   * Defaults to [TypeSafeAccessorInference.STRICT]
    *
    * @see <a href="https://docs.gradle.org/current/userguide/declaring_dependencies_basics.html#sec:type-safe-project-accessors">Gradle type-safe project accessors docs</a>
    */

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/dsl/SpotlightExtension.kt
@@ -3,6 +3,7 @@ package com.fueledbycaffeine.spotlight.dsl
 import com.fueledbycaffeine.spotlight.SpotlightSettingsPlugin
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.IDE_PROJECTS_LOCATION
+import com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.file.BuildLayout
 import org.gradle.api.model.ObjectFactory
@@ -34,7 +35,7 @@ public abstract class SpotlightExtension @Inject constructor(
   /**
    * Sets the level of processing to be done to support type-safe project accessors.
    *
-   * Defaults to [TypeSafeAccessorInference.STRICT]
+   * Defaults to [com.fueledbycaffeine.spotlight.buildscript.TypeSafeAccessorInference.STRICT]
    *
    * @see <a href="https://docs.gradle.org/current/userguide/declaring_dependencies_basics.html#sec:type-safe-project-accessors">Gradle type-safe project accessors docs</a>
    */

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
@@ -4,8 +4,8 @@ import com.fueledbycaffeine.spotlight.SpotlightBuildService
 import com.fueledbycaffeine.spotlight.SpotlightBuildService.Companion.NAME
 import com.fueledbycaffeine.spotlight.buildscript.GRADLE_PATH_SEP
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
-import org.gradle.api.initialization.Settings
 import java.io.FileNotFoundException
+import org.gradle.api.initialization.Settings
 
 internal fun Settings.guessProjectsFromTaskRequests(): Set<GradlePath> {
   return startParameter.taskRequests.flatMap { it.args }

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/SpotlightProjectService.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/SpotlightProjectService.kt
@@ -80,8 +80,7 @@ class SpotlightProjectService(
           val rules = readRules()
           val implicitRules = rules.implicitRules
           val typeSafeInferenceLevel = rules.typeSafeAccessorInference ?: TypeSafeAccessorInference.DISABLED
-          val projectName = rules.projectName ?: project.name
-          val ruleSet = computeSpotlightRules(rootDir, projectName, implicitRules, typeSafeInferenceLevel) { allProjects.value }
+          val ruleSet = computeSpotlightRules(rootDir, project.name, implicitRules, typeSafeInferenceLevel) { allProjects.value }
           val allPaths = BreadthFirstSearch.flatten(paths, ruleSet)
           _ideProjects.emit(allPaths)
         }

--- a/spotlight-idea-plugin/src/main/resources/messages/SpotlightBundle.properties
+++ b/spotlight-idea-plugin/src/main/resources/messages/SpotlightBundle.properties
@@ -2,6 +2,6 @@ notification.project.not.indexed=Project {0} is not currently indexed by Spotlig
 notification.action.add.addOnly=Add to Spotlight
 notification.action.add.addAndSync=Add to Spotlight and Sync
 statusbar.widget.name=Spotlight
-statusbar.widget.tooltip=Spotlight is active ({0} projects specified)
+statusbar.widget.tooltip=Spotlight is active ({0} projects indexed)
 statusbar.widget.text.active=Spotlight is active
 statusbar.widget.text.inactive=Spotlight is not active


### PR DESCRIPTION
This is a fast-follow to the IDE integration of ide-projects to resolve transitives of ide-projects in the IDE plugin, with a bit of refactoring to share logic better with the gradle side of things.

**API changes**
- Move `TypeSafeAccessorInference` to the buildscript util artifact for reuse.
- Create a new `SpotlightRules` model for the JSON, which includes the existing `implicitRules` and also adds properties for `projectName` and `typeSafeAccessorInference`. Gradle will still use the values resolved from gradle, but these properties in JSON allow the IDE plugin to know this information as well.
  - There might be a better way to read this from the gradle model in the future, I'm not super familiar with how to do that. If we do, we might want to move the IDE plugin to entirely read from gradle (including implicit rules) rather than JSON.
  - The legacy format (a set of implicit rules) is still supported for now as a fallback
- `SpotlightRulesList.read()` now returns `SpotlightRules`