### PR TITLE
Support glob patterns in ide-projects.txt

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectList.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectList.kt
@@ -1,34 +1,31 @@
 package com.fueledbycaffeine.spotlight.buildscript
 
+import java.nio.file.FileSystems
 import java.nio.file.Path
 import kotlin.io.path.createFile
 import kotlin.io.path.notExists
 import kotlin.io.path.readLines
 import kotlin.io.path.writeText
 
-public class SpotlightProjectList internal constructor(private val buildRoot: Path, public val projectList: Path) {
+public sealed interface SpotlightProjectList {
+  public val buildRoot: Path
+  public val projectList: Path
+
   public companion object {
     private const val COMMENT_CHAR = "#"
     public const val ALL_PROJECTS_LOCATION: String = "gradle/all-projects.txt"
     public const val IDE_PROJECTS_LOCATION: String = "gradle/ide-projects.txt"
 
     @JvmStatic
-    public fun allProjects(buildRoot: Path): SpotlightProjectList =
-      SpotlightProjectList(buildRoot, buildRoot.resolve(ALL_PROJECTS_LOCATION))
+    public fun allProjects(buildRoot: Path): AllProjects =
+      AllProjects(buildRoot, buildRoot.resolve(ALL_PROJECTS_LOCATION))
 
     @JvmStatic
-    public fun ideProjects(buildRoot: Path): SpotlightProjectList =
-      SpotlightProjectList(buildRoot, buildRoot.resolve(IDE_PROJECTS_LOCATION))
+    public fun ideProjects(buildRoot: Path, allProjects: Set<GradlePath>? = null): IdeProjects =
+      IdeProjects(buildRoot, buildRoot.resolve(IDE_PROJECTS_LOCATION), allProjects)
   }
 
-  public fun read(): Set<GradlePath> {
-    if (projectList.notExists()) return emptySet()
-
-    return projectList.readLines()
-      .filterNot { line -> line.trim().startsWith(COMMENT_CHAR) || line.isBlank() }
-      .map { GradlePath(buildRoot, it) }
-      .toSet()
-  }
+  public fun read(): Set<GradlePath>
 
   public infix fun contains(path: GradlePath): Boolean = read().contains(path)
 
@@ -44,5 +41,79 @@ public class SpotlightProjectList internal constructor(private val buildRoot: Pa
   public fun remove(paths: Iterable<GradlePath>) {
     if (projectList.notExists()) return
     projectList.writeText((read().filter { it !in paths }).joinToString("\n") { it.path })
+  }
+
+  public fun readRawPaths(): List<String> {
+    if (projectList.notExists()) return emptyList()
+    return projectList.readLines()
+      .filterNot { line -> line.trim().startsWith(COMMENT_CHAR) || line.isBlank() }
+  }
+}
+
+public class AllProjects internal constructor(
+  override val buildRoot: Path,
+  override val projectList: Path
+) : SpotlightProjectList {
+
+  override fun read(): Set<GradlePath> {
+    return readRawPaths()
+      .map { GradlePath(buildRoot, it) }
+      .toSet()
+  }
+}
+
+public class IdeProjects internal constructor(
+  override val buildRoot: Path,
+  override val projectList: Path,
+  private val allProjects: Set<GradlePath>? = null
+) : SpotlightProjectList {
+
+  private companion object {
+    private const val STAR_CHAR = '*'
+    private const val QUESTION_CHAR = '?'
+
+    private fun String.containsGlobChar(): Boolean {
+      for (char in this) {
+        if (char == STAR_CHAR || char == QUESTION_CHAR) {
+          return true
+        }
+      }
+      return false
+    }
+  }
+
+  override fun read(): Set<GradlePath> {
+    val rawPaths = readRawPaths()
+
+    return if (allProjects != null) {
+      // Apply filtering when allProjects is provided
+      rawPaths.flatMap { path ->
+        when {
+          path.containsGlobChar() -> {
+            // Handle glob patterns like :libraries:*
+            val globPattern = "glob:$path"
+            val pathMatcher = FileSystems.getDefault().getPathMatcher(globPattern)
+            allProjects.filter { gradlePath ->
+              // Convert gradle path to a Path for matching
+              val pathToMatch = FileSystems.getDefault().getPath(gradlePath.path)
+              pathMatcher.matches(pathToMatch)
+            }
+          }
+
+          else -> {
+            // Direct project reference
+            val gradlePath = GradlePath(buildRoot, path)
+            if (allProjects.contains(gradlePath)) {
+              listOf(gradlePath)
+            } else {
+              emptyList()
+            }
+          }
+        }
+      }.toSet()
+    } else {
+      // Default behavior when no allProjects provided
+      rawPaths.map { GradlePath(buildRoot, it) }.toSet()
+    }
   }
 }

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightProjectListTest.kt
@@ -25,7 +25,7 @@ class SpotlightProjectListTest {
     )
     projectListFile.writeText(expectedProjects.joinToString("\n") { it.path })
 
-    val projects = SpotlightProjectList(buildRoot, projectListFile).read()
+    val projects = AllProjects(buildRoot, projectListFile).read()
     assertThat(projects).equals(expectedProjects)
   }
 
@@ -40,7 +40,7 @@ class SpotlightProjectListTest {
       :foo
     """.trimIndent())
 
-    val projects = SpotlightProjectList(buildRoot, projectListFile).read()
+    val projects = AllProjects(buildRoot, projectListFile).read()
     assertThat(projects).equals(expectedProjects)
   }
 
@@ -57,7 +57,7 @@ class SpotlightProjectListTest {
       :foo:bar
     """.trimIndent())
 
-    val projects = SpotlightProjectList(buildRoot, projectListFile).read()
+    val projects = AllProjects(buildRoot, projectListFile).read()
     assertThat(projects).equals(expectedProjects)
   }
 
@@ -72,7 +72,7 @@ class SpotlightProjectListTest {
       :foo
     """.trimIndent())
 
-    val projects = SpotlightProjectList(buildRoot, projectListFile).read()
+    val projects = AllProjects(buildRoot, projectListFile).read()
     assertThat(projects).equals(expectedProjects)
   }
 
@@ -88,7 +88,7 @@ class SpotlightProjectListTest {
 
     val present = GradlePath(buildRoot, ":foo")
     val missing = GradlePath(buildRoot, ":bar")
-    val projects = SpotlightProjectList(buildRoot, projectListFile)
+    val projects = AllProjects(buildRoot, projectListFile)
     assertThat(projects.contains(missing)).isFalse()
     assertThat(projects.contains(present)).isTrue()
   }
@@ -105,10 +105,68 @@ class SpotlightProjectListTest {
     """.trimIndent())
 
     val missing = GradlePath(buildRoot, ":bar")
-    val projects = SpotlightProjectList(buildRoot, projectListFile)
+    val projects = AllProjects(buildRoot, projectListFile)
     projects.add(listOf(missing))
     val updatedFileContents = projectListFile.readText()
     assertThat(updatedFileContents).equals(":foo\n:bar\n")
+  }
+
+  @Test
+  fun `IdeProjects supports glob patterns`() {
+    val ideProjectListFile = buildRoot.resolve("ide-projects.txt")
+    val allProjectsList = buildRoot.createProjectList(
+      ":libraries:core",
+      ":libraries:ui",
+      ":libraries:data",
+      ":apps:main",
+      ":apps:sample"
+    )
+    ideProjectListFile.writeText("""
+      :libraries:*
+      :apps:main
+    """.trimIndent())
+
+    val projects = IdeProjects(buildRoot, ideProjectListFile, allProjectsList.toSet()).read()
+    val expectedProjects = allProjectsList.filter {
+      it.path in setOf(":libraries:core",
+        ":libraries:ui",
+        ":libraries:data",
+        ":apps:main")
+    }
+    assertThat(projects).equals(expectedProjects.toSet())
+  }
+
+  @Test
+  fun `IdeProjects filters non-existent projects when allProjects provided`() {
+    val ideProjectListFile = buildRoot.resolve("ide-projects.txt")
+    val allProjectsList = buildRoot.createProjectList(
+      ":foo",
+      ":bar"
+    )
+    ideProjectListFile.writeText("""
+      :foo
+      :baz
+    """.trimIndent())
+
+    val projects = IdeProjects(buildRoot, ideProjectListFile, allProjectsList.toSet()).read()
+    val expectedProjects = allProjectsList.filter { it.path == ":foo" }
+    assertThat(projects).equals(expectedProjects.toSet())
+  }
+
+  @Test
+  fun `IdeProjects works without allProjects`() {
+    val ideProjectListFile = buildRoot.resolve("ide-projects.txt")
+    val projects = buildRoot.createProjectList(
+      ":foo",
+      ":bar"
+    )
+    ideProjectListFile.writeText("""
+      :foo
+      :bar
+    """.trimIndent())
+
+    val ideProjects = IdeProjects(buildRoot, ideProjectListFile, null).read()
+    assertThat(ideProjects).equals(projects.toSet())
   }
 
   private fun Path.createProjectList(vararg projects: String): List<GradlePath> {

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -52,7 +52,8 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
       implicitAndTransitiveDependenciesOf(projectsOverride)
     } else {
       if (isIdeSync) {
-        val targets = getIdeProjects()
+        val allProjects = getAllProjects()
+        val targets = getIdeProjects(allProjects)
         if (targets.isNotEmpty()) {
           logger.info("{} contains {} targets", SpotlightProjectList.IDE_PROJECTS_LOCATION, targets.size)
           implicitAndTransitiveDependenciesOf(targets)
@@ -61,7 +62,7 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
             "{} was missing or empty, including all projects. This can result in slow sync times!",
             SpotlightProjectList.IDE_PROJECTS_LOCATION,
           )
-          getAllProjects()
+          allProjects
         }
       } else {
         // TODO: why does start parameters never have a nonnull project path and the task paths are just listed in the args?
@@ -116,6 +117,6 @@ public class SpotlightSettingsPlugin: Plugin<Settings> {
   }
 
   private fun Settings.getAllProjects() = SpotlightProjectList.allProjects(settingsDir.toPath()).read()
-  private fun Settings.getIdeProjects() = SpotlightProjectList.ideProjects(settingsDir.toPath()).read()
+  private fun Settings.getIdeProjects(allProjects: Set<GradlePath>) = SpotlightProjectList.ideProjects(settingsDir.toPath(), allProjects).read()
   private fun Settings.getSpotlightRules() = SpotlightRulesList(settingsDir.toPath()).read()
 }

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/SpotlightProjectService.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/SpotlightProjectService.kt
@@ -38,7 +38,6 @@ class SpotlightProjectService(
 ) : Disposable {
 
   private val rootDir = Path.of(project.basePath!!)
-  private val ideProjectsList = SpotlightProjectList.ideProjects(rootDir)
   private val allProjectsList = SpotlightProjectList.allProjects(rootDir)
   private val rulesList = SpotlightRulesList(rootDir)
 
@@ -77,6 +76,7 @@ class SpotlightProjectService(
     withContext(Dispatchers.IO) {
       when (changeType) {
         SpotlightFileChangeType.IDE_PROJECTS -> {
+          val ideProjectsList = SpotlightProjectList.ideProjects(rootDir, allProjects.value)
           val paths = ideProjectsList.read()
           val currentRules = rules.value
           val implicitRules = currentRules.implicitRules
@@ -103,20 +103,24 @@ class SpotlightProjectService(
   }
 
   fun addIdeProjects(paths: Iterable<GradlePath>) {
+    val ideProjectsList = SpotlightProjectList.ideProjects(rootDir)
     ideProjectsList.add(paths)
     refreshIdeProjectsFile()
   }
 
   fun removeIdeProjects(pathsInBuild: Set<GradlePath>) {
+    val ideProjectsList = SpotlightProjectList.ideProjects(rootDir)
     ideProjectsList.remove(pathsInBuild)
     refreshIdeProjectsFile()
   }
 
   private fun ideProjectsFile(): VirtualFile? {
+    val ideProjectsList = SpotlightProjectList.ideProjects(rootDir)
     return VirtualFileManager.getInstance().findFileByNioPath(ideProjectsList.projectList)
   }
 
   fun openIdeProjectsInEditor() {
+    val ideProjectsList = SpotlightProjectList.ideProjects(rootDir)
     ideProjectsList.ensureFileExists()
     val virtualFile = ideProjectsFile() ?: return
     FileEditorManager.getInstance(project)


### PR DESCRIPTION
This introduces support for basic glob patterns in `ide-projects.txt`. Part of this also involved converting `SpotlightProjectList` to be a sealed interface, given that the underlying impls are a bit diverged with this.