### PR TITLE
Fall back to finding any *.gradle(.kts) script

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFile.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFile.kt
@@ -8,6 +8,7 @@ import com.fueledbycaffeine.spotlight.buildscript.graph.ImplicitDependencyRule.P
 import com.fueledbycaffeine.spotlight.buildscript.graph.StrictModeTypeSafeProjectAccessorRule
 import com.fueledbycaffeine.spotlight.buildscript.graph.TypeSafeProjectAccessorRule
 import com.gradle.scan.plugin.internal.com.fueledbycaffeine.spotlight.internal.ccHiddenReadLines
+import java.io.FileNotFoundException
 
 public data class BuildFile(public val project: GradlePath) {
   public fun parseDependencies(
@@ -111,7 +112,7 @@ private fun computeImplicitParentProjects(project: GradlePath): Set<GradlePath> 
   // libs/foo/impl/build.gradle.kts -> libs/foo
   // Then iterate up to the root directory
   val sequence = generateSequence(project) { it.parent }
-  return sequence.filterTo(mutableSetOf()) { it != project && it.hasBuildFile }
+  return sequence.filterTo(mutableSetOf()) { it != project && !it.isRootProject }
 }
 
 private fun String.removeTypeSafeAccessorJunk(rootProjectAccessor: String): String =

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/GradlePath.kt
@@ -38,7 +38,8 @@ public data class GradlePath(
   )
 
   /**
-   * Indicates if this project path has either a build.gradle or a build.gradle.kts script
+   * Indicates if this project path has either a build.gradle, build.gradle.kts, or some other
+   * *.gradle(.kts) script.
    */
   public val hasBuildFile: Boolean get() = GradlePathInternal.hasBuildFile(this)
 
@@ -52,13 +53,9 @@ public data class GradlePath(
    *
    * @throws FileNotFoundException if there is no buildscript.
    */
-  public val buildFilePath: Path get() = try {
+  public val buildFilePath: Path get() =
     GradlePathInternal.buildFilePath(this)
-  } catch (_: GradlePathInternal.NoBuildFileException) {
-    // The package for GradlePathInternal is really weird and possibly confusing so make it look like the exception
-    // came from here in the public API.
-    throw FileNotFoundException("No build.gradle(.kts) for $path found")
-  }
+      ?: throw FileNotFoundException("No *.gradle(.kts) for $path found")
 
   /**
    * The equivalent type-safe project accessor of [path] used to reference this Gradle project in a buildscript

--- a/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/GradlePathInternal.kt
+++ b/buildscript-utils/src/main/kotlin/com/gradle/scan/plugin/internal/com/fueledbycaffeine/spotlight/internal/GradlePathInternal.kt
@@ -21,23 +21,30 @@ import com.fueledbycaffeine.spotlight.buildscript.GRADLE_SCRIPT_KOTLIN
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT
 import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT_KOTLIN
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
 
 internal object GradlePathInternal {
-  fun hasBuildFile(gradlePath: GradlePath): Boolean =
-    gradlePath.projectDir.resolve(GRADLE_SCRIPT).exists() ||
-      gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists()
+  private val SCRIPT_REGEX = Regex(".*\\.gradle(\\.kts)?$")
+
+  fun hasBuildFile(gradlePath: GradlePath): Boolean = buildFilePath(gradlePath) != null
 
   fun hasSettingsFile(gradlePath: GradlePath): Boolean =
     gradlePath.projectDir.resolve(SETTINGS_SCRIPT).exists() ||
       gradlePath.projectDir.resolve(SETTINGS_SCRIPT_KOTLIN).exists()
 
-  fun buildFilePath(gradlePath: GradlePath): Path = when {
+  fun buildFilePath(gradlePath: GradlePath): Path? = when {
     gradlePath.projectDir.resolve(GRADLE_SCRIPT).exists() -> gradlePath.projectDir.resolve(GRADLE_SCRIPT)
     gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN).exists() -> gradlePath.projectDir.resolve(GRADLE_SCRIPT_KOTLIN)
-    else -> throw NoBuildFileException()
+    else -> {
+      if (gradlePath.projectDir.exists()) {
+        Files.newDirectoryStream(gradlePath.projectDir) { path ->
+          !Files.isDirectory(path) && path.fileName.toString().matches(SCRIPT_REGEX)
+        }.use { it.firstOrNull() }
+      } else {
+        null
+      }
+    }
   }
-
-  class NoBuildFileException : Exception()
 }

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
@@ -222,6 +222,7 @@ class BuildFileTest {
     )
     assertThat(buildFile.parseDependencies(rules))
       .containsExactlyInAnyOrder(
+        GradlePath(buildRoot, ":features"),
         GradlePath(buildRoot, ":foo"),
         GradlePath(buildRoot, ":bar"),
       )
@@ -248,6 +249,7 @@ class BuildFileTest {
     )
     assertThat(buildFile.parseDependencies(rules))
       .containsExactlyInAnyOrder(
+        GradlePath(buildRoot, ":features"),
         GradlePath(buildRoot, ":foo"),
         GradlePath(buildRoot, ":bar"),
       )

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/graph/GradlePathTest.kt
@@ -18,6 +18,7 @@ import kotlin.io.path.createFile
 import kotlin.io.path.writeText
 import org.gradle.internal.scripts.ScriptingLanguages
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
@@ -55,6 +56,19 @@ class GradlePathTest {
     projectDir.createDirectories()
     val buildscripts = ScriptingLanguages.all().map { lang ->
       val buildScriptPath = projectDir.resolve("build${lang.extension}")
+      buildScriptPath.createFile()
+    }
+    // Some other script
+    projectDir.resolve("project.gradle").createFile()
+    assertThat(gradlePath.buildFilePath).equals(buildscripts.first())
+  }
+
+  @Test fun `fall back to any other buildscript`() {
+    val gradlePath = GradlePath(buildRoot, ":foo:bar")
+    val projectDir = buildRoot.resolve("foo/bar")
+    projectDir.createDirectories()
+    val buildscripts = ScriptingLanguages.all().map { lang ->
+      val buildScriptPath = projectDir.resolve("bar${lang.extension}")
       buildScriptPath.createFile()
     }
     assertThat(gradlePath.buildFilePath).equals(buildscripts.first())

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
@@ -2,9 +2,7 @@ package com.fueledbycaffeine.spotlight.utils
 
 import com.fueledbycaffeine.spotlight.SpotlightBuildService
 import com.fueledbycaffeine.spotlight.SpotlightBuildService.Companion.NAME
-import com.fueledbycaffeine.spotlight.buildscript.GRADLE_PATH_SEP
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
-import java.io.FileNotFoundException
 import org.gradle.api.initialization.Settings
 
 internal fun Settings.guessProjectsFromTaskRequests(): Set<GradlePath> {


### PR DESCRIPTION
Having every build file be called `build.gradle` leads to poor navigation experience for builds with many projects. Gradle allows relocating/renaming the buildscript via settings plugin and some users do this to name the buildscript after the project (e.g. `project-name.gradle.kts`), making it easier to navigate to.

Spotlight can easily support this by falling back to returning the first `.gradle(.kts)` file found if `build.gradle` and `build.gradle.kts` don't exist.