### PR TITLE
Ensure that `checkAllProjectsList` and `fixAllProjectsList` tasks use equivalent formatting

### DIFF
--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
@@ -21,7 +21,7 @@ class SpotlightLintTasksFunctionalTest {
     val project = SpiritboxProject().build()
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
-    allProjects.writeText(allProjects.readLines().sorted().reversed().joinToString("\n"))
+    allProjects.writeText(allProjects.readLines().sorted().reversed().joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.buildAndFail(":${CheckSpotlightProjectListTask.NAME}")
@@ -31,12 +31,27 @@ class SpotlightLintTasksFunctionalTest {
   }
 
   @Test
-  fun `check all-projects list succeeds when sorted`() {
+  fun `check all-projects list fails when sorted but not formatted`() {
     // Given
     val project = SpiritboxProject().build()
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
     allProjects.writeText(allProjects.readLines().sorted().joinToString("\n"))
+
+    // When
+    val result = project.buildAndFail(":${CheckSpotlightProjectListTask.NAME}")
+
+    // Then
+    assertThat(result).task(":${CheckSpotlightProjectListTask.NAME}").failed()
+  }
+
+  @Test
+  fun `check all-projects list succeeds when sorted and formatted`() {
+    // Given
+    val project = SpiritboxProject().build()
+    project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
+    val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
+    allProjects.writeText(allProjects.readLines().sorted().joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.build(":${CheckSpotlightProjectListTask.NAME}")
@@ -52,7 +67,7 @@ class SpotlightLintTasksFunctionalTest {
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
     val allProjectsList = allProjects.readLines().sorted().reversed()
-    allProjects.writeText(allProjectsList.joinToString("\n"))
+    allProjects.writeText(allProjectsList.joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.build(":${FixSpotlightProjectListTask.NAME}")
@@ -69,7 +84,7 @@ class SpotlightLintTasksFunctionalTest {
     val project = SpiritboxProject().build()
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
-    allProjects.writeText(allProjects.readLines().sorted().joinToString("\n"))
+    allProjects.writeText(allProjects.readLines().sorted().joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.build(":check")
@@ -87,7 +102,7 @@ class SpotlightLintTasksFunctionalTest {
 
     // Ensure all-projects list is sorted first
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
-    allProjects.writeText(allProjects.readLines().sorted().joinToString("\n"))
+    allProjects.writeText(allProjects.readLines().sorted().joinToString(separator = "\n", postfix = "\n"))
 
     // Create a build file for a project that would be included
     val someProject = project.rootDir.resolve("some-project")
@@ -118,7 +133,7 @@ class SpotlightLintTasksFunctionalTest {
     val project = SpiritboxProject().build(dslKind = dslKind)
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
     val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
-    allProjects.writeText(allProjects.readLines().sorted().joinToString("\n"))
+    allProjects.writeText(allProjects.readLines().sorted().joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.build(":${CheckSpotlightProjectListTask.NAME}")
@@ -137,7 +152,7 @@ class SpotlightLintTasksFunctionalTest {
     // Add a project path that doesn't have a build file
     val projectsList = allProjects.readLines().toMutableList()
     projectsList.add(":missing-build-file")
-    allProjects.writeText(projectsList.sorted().joinToString("\n"))
+    allProjects.writeText(projectsList.sorted().joinToString(separator = "\n", postfix = "\n"))
 
     // Create the directory but no build file
     project.rootDir.resolve("missing-build-file").mkdirs()
@@ -164,7 +179,7 @@ class SpotlightLintTasksFunctionalTest {
     val projectsList = allProjects.readLines()
       .filterNot { it.startsWith(":rotoscope:") }
       .sorted() // Keep it sorted so checkSorted() passes
-    allProjects.writeText(projectsList.joinToString("\n"))
+    allProjects.writeText(projectsList.joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.buildAndFail(":${CheckSpotlightProjectListTask.NAME}")
@@ -211,8 +226,8 @@ class SpotlightLintTasksFunctionalTest {
     val originalProjectsList = allProjects.readLines()
     val projectsList = originalProjectsList
       .filterNot { it.startsWith(":rotoscope:") }
-    allProjects.writeText(projectsList.joinToString("\n"))
-    
+    allProjects.writeText(projectsList.joinToString(separator = "\n", postfix = "\n"))
+
     val expectedMissingCount = originalProjectsList.count { it.startsWith(":rotoscope:") }
 
     // When
@@ -264,7 +279,7 @@ class SpotlightLintTasksFunctionalTest {
 
     // Unsort the list
     val projectsList = allProjects.readLines().sorted().reversed()
-    allProjects.writeText(projectsList.joinToString("\n"))
+    allProjects.writeText(projectsList.joinToString(separator = "\n", postfix = "\n"))
 
     // When
     val result = project.build(":${FixSpotlightProjectListTask.NAME}")
@@ -287,7 +302,7 @@ class SpotlightLintTasksFunctionalTest {
       .filterNot { it.startsWith(":rotoscope:") }
       .toMutableList()
     projectsList.add(":invalid-project")
-    allProjects.writeText(projectsList.joinToString("\n"))
+    allProjects.writeText(projectsList.joinToString(separator = "\n", postfix = "\n"))
     project.rootDir.resolve("invalid-project").mkdirs()
 
     // When: First fix to resolve issues

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
@@ -227,7 +227,7 @@ class SpotlightLintTasksFunctionalTest {
     val projectsList = originalProjectsList
       .filterNot { it.startsWith(":rotoscope:") }
     allProjects.writeText(projectsList.joinToString(separator = "\n", postfix = "\n"))
-
+    
     val expectedMissingCount = originalProjectsList.count { it.startsWith(":rotoscope:") }
 
     // When

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/SpiritboxProject.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/SpiritboxProject.kt
@@ -214,7 +214,7 @@ class SpiritboxProject : AbstractGradleProject() {
     project.gradleDir.mkdirs()
     project.allProjects.createNewFile()
     project.ideProjects.createNewFile()
-    project.allProjects.writeText(projectPaths.joinToString("\n"))
+    project.allProjects.writeText(projectPaths.joinToString(separator = "\n", postfix = "\n"))
 
     return project
   }

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/CheckSpotlightProjectListTask.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/CheckSpotlightProjectListTask.kt
@@ -4,6 +4,7 @@ import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT
 import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT_KOTLIN
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
 import com.fueledbycaffeine.spotlight.buildscript.graph.BreadthFirstSearch
+import com.fueledbycaffeine.spotlight.utils.asSortedProjectsContent
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.DirectoryProperty
@@ -43,7 +44,7 @@ public abstract class CheckSpotlightProjectListTask : DefaultTask() {
     val file = projectsFile.asFile.get()
     val current = file.readLines()
 
-    if (current != current.sorted()) {
+    if (file.readText() != current.asSortedProjectsContent()) {
       throw InvalidUserDataException(
         """
         Spotlight's list of all projects is not sorted: ${file.path}

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/FixSpotlightProjectListTask.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/FixSpotlightProjectListTask.kt
@@ -5,6 +5,7 @@ import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT
 import com.fueledbycaffeine.spotlight.buildscript.SETTINGS_SCRIPT_KOTLIN
 import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
 import com.fueledbycaffeine.spotlight.buildscript.graph.BreadthFirstSearch
+import com.fueledbycaffeine.spotlight.utils.asSortedProjectsContent
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -92,8 +93,8 @@ public abstract class FixSpotlightProjectListTask : DefaultTask() {
   }
 
   private fun writeSortedProjects(projects: Set<GradlePath>) {
-    val sortedProjectPaths = projects.map { it.path }.sorted()
-    projectsFile.asFile.get().writeText(sortedProjectPaths.joinToString("\n"))
+    val sortedProjectPaths = projects.map { it.path }
+    projectsFile.asFile.get().writeText(sortedProjectPaths.asSortedProjectsContent())
   }
 
   private fun logResults(removedCount: Int, addedCount: Int) {

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/utils/GradlePathExt.kt
@@ -23,3 +23,7 @@ private val String.projectPathGuess get() = this.replace(Regex("\\w+$"), "")
 internal fun Settings.include(paths: Iterable<GradlePath>) {
   include(paths.map { it.path })
 }
+
+internal fun List<String>.asSortedProjectsContent(): String {
+  return sorted().joinToString(separator = "\n", postfix = "\n")
+}


### PR DESCRIPTION
Creates a `List<String>.asSortedProjectsContent(): String` function that is used by both `checkAllProjectsList` and `fixAllProjectsList` to produce the content of `all-projects.txt`. Previously, `checkAllProjectsList` would just check that the content was sorted or not and fail. Now, it extracts the projects, produces the sorted content using the extension function created, and asserts that the string matches the content of the file. 

An additional change is that this requires that the `all-projects.txt` file end in a newline, which required changing some of the functional tests that did not add newlines to the test file.