### PR TITLE
Fix duplicate Spotlight logging

### DIFF
--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -231,6 +231,7 @@ class SpotlightBuildFunctionalTest {
     // Then
     assertThat(result).task(":help").succeeded()
     assertThat(result).output().contains("Requested targets include 0 projects transitively")
+    assertThat(result.output.lines().filter { it.contains("Spotlight included") }).hasSize(1)
     val includedProjects = result.includedProjects()
     assertThat(includedProjects).containsExactly(project.rootProject.settingsScript.rootProjectName)
     val ccReport = result.ccReport()

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
@@ -89,7 +89,6 @@ internal abstract class SpotlightIncludedProjectsValueSource : ValueSource<Set<G
       }
     }.toSet()
 
-    logger.lifecycle("Spotlight included {} projects", mainBuildProjects.size)
     return mainBuildProjects
   }
 

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightSettingsPlugin.kt
@@ -14,8 +14,11 @@ import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.Logging
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import javax.inject.Inject
+
+private val logger = Logging.getLogger(SpotlightSettingsPlugin::class.java)
 
 /**
  * A [Settings] plugin to ease management of projects included in large builds.
@@ -47,6 +50,7 @@ public abstract class SpotlightSettingsPlugin @Inject constructor(
 public fun Settings.applySpotlightConfiguration(): Unit = settings.run {
   val extension = extensions.getSpotlightExtension()
   val includedProjects = SpotlightIncludedProjectsValueSource.of(this, extension).get()
+  logger.lifecycle("Spotlight included {} projects", includedProjects.size)
   include(includedProjects)
 
   // Report Spotlight metrics to Develocity if available


### PR DESCRIPTION
Move the log from `ValueSource.obtain()` to the call site so Gradle re-evaluations don't produce duplicate lines.