### PR TITLE
Resolve project accessors with backticks

### DIFF
--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/parser/impl/RegexBuildscriptParser.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/parser/impl/RegexBuildscriptParser.kt
@@ -19,7 +19,7 @@ public object RegexBuildscriptParser : BuildscriptParser {
   }
 
   private val PROJECT_DEP_PATTERN = Regex("""project\s*\((['"])(.*?)\1\)""")
-  private val TYPESAFE_PROJECT_DEP_PATTERN = Regex("""\b(projects\.[\w.]+)\b""")
+  private val TYPESAFE_PROJECT_DEP_PATTERN = Regex("""\b(projects(?:\.(?:`[^`]+`|\w+))+)""")
   private val STRING_LITERAL_PATTERN = Regex("\"[^\"]*\"|'[^']*'")
   private val BLOCK_COMMENT_PATTERN = Regex("/\\*.*?\\*/", RegexOption.DOT_MATCHES_ALL)
 
@@ -58,7 +58,8 @@ public object RegexBuildscriptParser : BuildscriptParser {
   }
 
   private fun String.removeTypeSafeAccessorJunk(rootProjectAccessor: String): String =
-    this.removePrefix("projects.")
+    this.replace("`", "") // accessors for kotlin keywords (e.g. `interface`) are escaped with backticks
+      .removePrefix("projects.")
       .removePrefix("$rootProjectAccessor.")
       .removeSuffix(".dependencyProject") // deprecated in gradle, to be removed in 9.0
       .removeSuffix(".path") // GeneratedClassCompilationException if you try to name a project `:path` lol

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/BuildFileTest.kt
@@ -161,6 +161,30 @@ class BuildFileTest {
 
 
 
+  @Test
+  fun `reads type-safe project accessor dependencies that use backticks for kotlin keywords`() {
+    // Backtick-escaped accessors are only valid in the Kotlin DSL, where `interface` is a keyword.
+    val project = buildRoot.createProject(":foo", BuildFileType.KOTLIN)
+    val interfaceProject = buildRoot.createProject(":foo:interface", BuildFileType.KOTLIN)
+    val implProject = buildRoot.createProject(":foo:impl", BuildFileType.KOTLIN)
+
+    project.buildFilePath.writeText("""
+      dependencies {
+        api(projects.foo.`interface`)
+        implementation(projects.foo.impl)
+      }
+      """.trimIndent())
+
+    val buildFile = BuildFile(project)
+    val accessorMap = mapOf(
+      "foo.interface" to interfaceProject,
+      "foo.impl" to implProject,
+    )
+    val rule = TypeSafeProjectAccessorRule("spotlight", accessorMap)
+    assertThat(buildFile.parseDependencies(setOf(rule)))
+      .containsExactlyInAnyOrder(interfaceProject, implProject)
+  }
+
   @ParameterizedTest
   @EnumSource(BuildFileType::class)
   fun `reads type-safe project accessor dependencies that use explicit root project`(buildFileType: BuildFileType) {


### PR DESCRIPTION
Kotlin keyword module names (e.g. interface) are referenced with backtick-escaped accessors like projects.foo.`interface`. The regex stopped at the backtick and stripped backticks are now handled.

Fixes #115