### PR TITLE
Create `gradle/all-projects.txt` automatically in `fixAllProjectsList`

### DIFF
--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightLintTasksFunctionalTest.kt
@@ -79,6 +79,37 @@ class SpotlightLintTasksFunctionalTest {
   }
 
   @Test
+  fun `fix creates all-projects list when it does not exist`() {
+    // Given
+    val project = SpiritboxProject().build()
+    project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
+    val allProjects = project.rootDir.resolve(SpotlightProjectList.ALL_PROJECTS_LOCATION)
+    val settingsFile = project.rootDir.resolve("settings.gradle")
+
+    // Create a test project with a build file and include it via settings
+    val testProject = project.rootDir.resolve("test-project")
+    testProject.mkdirs()
+    testProject.resolve("build.gradle").createNewFile()
+    settingsFile.appendText("\ninclude ':test-project'\n")
+
+    // Remove the all-projects.txt file to reproduce the missing-file scenario
+    assertThat(allProjects.delete()).isTrue()
+    assertThat(allProjects.exists()).isFalse()
+
+    // When
+    val result = project.build(":${FixSpotlightProjectListTask.NAME}")
+
+    // Then
+    assertThat(result).task(":${FixSpotlightProjectListTask.NAME}").succeeded()
+    assertThat(allProjects.exists()).isTrue()
+    assertThat(allProjects.readLines()).contains(":test-project")
+
+    // Verify check passes after fix
+    val checkResult = project.build(":${CheckSpotlightProjectListTask.NAME}")
+    assertThat(checkResult).task(":${CheckSpotlightProjectListTask.NAME}").succeeded()
+  }
+
+  @Test
   fun `check runs check all-projects task`() {
     // Given
     val project = SpiritboxProject().build()

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/FixSpotlightProjectListTask.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/tasks/FixSpotlightProjectListTask.kt
@@ -9,10 +9,7 @@ import com.fueledbycaffeine.spotlight.utils.asSortedProjectsContent
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.work.DisableCachingByDefault
@@ -35,8 +32,8 @@ public abstract class FixSpotlightProjectListTask : DefaultTask() {
     public const val NAME: String = "fixAllProjectsList"
   }
 
-  @get:InputFile
-  @get:PathSensitive(PathSensitivity.RELATIVE)
+  // Not an @InputFile: the file may not exist yet, and this task creates it if missing.
+  @get:Internal
   internal abstract val projectsFile: RegularFileProperty
 
   @get:Internal
@@ -94,7 +91,9 @@ public abstract class FixSpotlightProjectListTask : DefaultTask() {
 
   private fun writeSortedProjects(projects: Set<GradlePath>) {
     val sortedProjectPaths = projects.map { it.path }
-    projectsFile.asFile.get().writeText(sortedProjectPaths.asSortedProjectsContent())
+    val file = projectsFile.asFile.get()
+    file.parentFile?.mkdirs()
+    file.writeText(sortedProjectPaths.asSortedProjectsContent())
   }
 
   private fun logResults(removedCount: Int, addedCount: Int) {


### PR DESCRIPTION
Fixes #114

The fix task declared projectsFile as `@InputFile`, which made Gradle fail validation when the file did not exist. Switch it to `@Internal` and create the file (and parent dir) when writing so the task works on a fresh project.