### PR TITLE
Don't show IDE banners when Spotlight plugin isn't applied

### DIFF
--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/direxclude/SpotlightExcludeDirectoryPolicy.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/direxclude/SpotlightExcludeDirectoryPolicy.kt
@@ -4,6 +4,7 @@ import com.fueledbycaffeine.spotlight.buildscript.GradlePath
 import com.fueledbycaffeine.spotlight.buildscript.minimize
 import com.fueledbycaffeine.spotlight.idea.SpotlightProjectService
 import com.fueledbycaffeine.spotlight.idea.gradle.SpotlightGradleProjectsService
+import com.fueledbycaffeine.spotlight.idea.gradle.SpotlightPluginStatus
 import com.fueledbycaffeine.spotlight.idea.settings.ExclusionPolicyMode
 import com.fueledbycaffeine.spotlight.idea.settings.SpotlightSettings
 import com.intellij.openapi.components.service
@@ -61,6 +62,9 @@ class SpotlightExcludeDirectoryPolicy(private val project: Project) : DirectoryI
     val service = project.service<SpotlightProjectService>()
     val gradleProjectsService = project.service<SpotlightGradleProjectsService>()
 
+    // The Spotlight Gradle plugin isn't applied, so don't exclude anything
+    if (gradleProjectsService.pluginStatus == SpotlightPluginStatus.NOT_APPLIED) return emptyArray()
+
     val allProjects = service.allProjects.value
     if (allProjects.isEmpty()) return emptyArray()
 
@@ -85,6 +89,9 @@ class SpotlightExcludeDirectoryPolicy(private val project: Project) : DirectoryI
   private fun getExcludedProjectDirectories(): Array<String> {
     val service = project.service<SpotlightProjectService>()
     val gradleProjectsService = project.service<SpotlightGradleProjectsService>()
+
+    // The Spotlight Gradle plugin isn't applied, so don't exclude anything
+    if (gradleProjectsService.pluginStatus == SpotlightPluginStatus.NOT_APPLIED) return emptyArray()
 
     // all-projects.txt is always the authoritative source for ALL projects
     val allProjects = service.allProjects.value

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightGradleProjectsService.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightGradleProjectsService.kt
@@ -1,20 +1,13 @@
 package com.fueledbycaffeine.spotlight.idea.gradle
 
 import com.fueledbycaffeine.spotlight.buildscript.GradlePath
-import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
-import com.fueledbycaffeine.spotlight.buildscript.SpotlightRulesList.Companion.SPOTLIGHT_RULES_LOCATION
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import java.nio.file.FileSystems
 import java.nio.file.Path
-import kotlin.io.path.exists
-import kotlin.io.path.readText
 
 /**
  * Service that stores the list of Gradle projects INCLUDED in the current build
@@ -29,180 +22,58 @@ class SpotlightGradleProjectsService(
   project: Project,
   scope: CoroutineScope,
 ) : Disposable {
-  private val rootDir = Path.of(project.basePath!!)
-  // We only use this to read raw paths, so allProjects lambda is not needed
-  private val ideProjectsList = SpotlightProjectList.ideProjects(rootDir) { emptySet() }
-  private val rulesPath = rootDir.resolve(SPOTLIGHT_RULES_LOCATION)
-
-  private val _includedProjects = MutableStateFlow<Set<GradlePath>>(emptySet())
-  
-  /**
-   * The normalized set of raw paths/patterns from ide-projects.txt at the time of the last sync.
-   * Used to detect meaningful changes that require a new sync.
-   */
-  private val _syncedRawPaths = MutableStateFlow<Set<String>>(emptySet())
-  
-  /**
-   * The content of spotlight-rules.json at the time of the last sync.
-   * Used to detect changes that require a new sync.
-   */
-  @Volatile
-  private var _syncedRulesContent: String? = null
-  
-  /**
-   * Whether at least one successful sync with Spotlight model data has completed.
-   */
-  @Volatile
-  private var _hasEverSynced = false
+  private val state = SpotlightSyncState(Path.of(project.basePath!!))
 
   /**
    * Projects that were INCLUDED in the most recent Gradle sync.
    * These are the projects that should be indexed in the IDE.
    * Empty set indicates no sync has completed yet.
    */
-  val includedProjects: StateFlow<Set<GradlePath>> = _includedProjects.asStateFlow()
+  val includedProjects: StateFlow<Set<GradlePath>> get() = state.includedProjects
 
   /**
    * Update the included projects from Gradle sync.
    * Called by [SpotlightModelDataService] during project import.
-   * Also records the current ide-projects.txt and spotlight-rules.json as the "synced" state.
    */
-  fun updateProjects(projectPaths: Set<String>) {
-    val gradlePaths = projectPaths
-      .map { GradlePath(rootDir, it) }
-      // Filter results to match what spotlight parses from build files where intermediate and root
-      // projects are omitted
-      .filter { it.hasBuildFile && it.path != ":" }
-      .toSet()
-    _includedProjects.value = gradlePaths
-    _hasEverSynced = true
-    
-    // Record the raw paths from ide-projects.txt at sync time
-    _syncedRawPaths.value = readCurrentRawPaths()
-    // Record the rules content at sync time
-    _syncedRulesContent = readCurrentRulesContent()
-  }
+  fun updateProjects(projectPaths: Set<String>) = state.updateProjects(projectPaths)
 
   /**
    * Check if Gradle sync has completed and we know which projects are included.
-   * Returns true once at least one sync has completed.
    */
-  val hasSyncedProjects: Boolean get() = _includedProjects.value.isNotEmpty()
-  
+  val hasSyncedProjects: Boolean get() = state.hasSyncedProjects
+
   /**
    * Check if at least one successful sync with Spotlight model data has completed.
    */
-  val hasEverSynced: Boolean get() = _hasEverSynced
+  val hasEverSynced: Boolean get() = state.hasEverSynced
 
   /**
-   * Clear the synced projects (e.g., when build configuration changes).
+   * Whether the Spotlight Gradle plugin was applied as of the most recent sync.
+   * Returns [SpotlightPluginStatus.UNKNOWN] if no sync has completed yet.
    */
-  fun clearProjects() {
-    _includedProjects.value = emptySet()
-    _syncedRawPaths.value = emptySet()
-    _syncedRulesContent = null
-  }
+  val pluginStatus: SpotlightPluginStatus get() = state.pluginStatus
 
   /**
-   * Check if the current ide-projects.txt or spotlight-rules.json has meaningful changes 
+   * Record that a sync completed without a Spotlight model, meaning the Spotlight Gradle
+   * plugin is not applied to this project.
+   */
+  fun markSpotlightNotApplied() = state.markSpotlightNotApplied()
+
+  /**
+   * Check if the current ide-projects.txt or spotlight-rules.json has meaningful changes
    * compared to what was synced, or if no sync has ever completed.
-   * Returns true if sync is needed.
    */
-  fun isSyncStale(): Boolean {
-    // If no sync has ever completed, it's stale (needs initial sync)
-    if (!_hasEverSynced) {
-      // Only consider stale if there's content in ide-projects.txt
-      return readCurrentRawPaths().isNotEmpty()
-    }
-    
-    // Check if rules have changed
-    if (haveRulesChanged()) return true
-    
-    // Check if ide-projects.txt has new paths
-    val currentPaths = readCurrentRawPaths()
-    val syncedPaths = _syncedRawPaths.value
-    
-    // Find paths that are in current but not in synced
-    val newPaths = currentPaths - syncedPaths
-    if (newPaths.isEmpty()) return false
-    
-    // Check if any new path is NOT covered by existing synced patterns
-    return newPaths.any { newPath -> !isPathCoveredByPatterns(newPath, syncedPaths) }
-  }
-  
+  fun isSyncStale(): Boolean = state.isSyncStale()
+
   /**
    * Check if spotlight-rules.json has changed since the last sync.
    */
-  fun haveRulesChanged(): Boolean {
-    val currentRules = readCurrentRulesContent()
-    val syncedRules = _syncedRulesContent
-    return currentRules != syncedRules
-  }
-  
+  fun haveRulesChanged(): Boolean = state.haveRulesChanged()
+
   /**
    * Returns the set of new paths/patterns in ide-projects.txt that aren't covered by the synced state.
    */
-  fun getUnsyncedPaths(): Set<String> {
-    if (!hasSyncedProjects) return emptySet()
-    
-    val currentPaths = readCurrentRawPaths()
-    val syncedPaths = _syncedRawPaths.value
-    
-    val newPaths = currentPaths - syncedPaths
-    return newPaths.filter { newPath -> !isPathCoveredByPatterns(newPath, syncedPaths) }.toSet()
-  }
-  
-  /**
-   * Read the current raw paths from ide-projects.txt, normalized (trimmed, no comments, sorted).
-   */
-  private fun readCurrentRawPaths(): Set<String> {
-    return ideProjectsList.readRawPaths(includeComments = false)
-      .map { it.trim() }
-      .toSet()
-  }
-  
-  /**
-   * Read the current content of spotlight-rules.json, or null if it doesn't exist.
-   */
-  private fun readCurrentRulesContent(): String? {
-    return if (rulesPath.exists()) {
-      rulesPath.readText()
-    } else {
-      null
-    }
-  }
-  
-  /**
-   * Check if a path is covered by any glob pattern in the given set of patterns.
-   */
-  private fun isPathCoveredByPatterns(path: String, patterns: Set<String>): Boolean {
-    // Direct paths are not covered by anything else (must be exact match)
-    if (!path.contains('*') && !path.contains('?')) {
-      // Check if any pattern in patterns covers this path
-      return patterns.any { pattern ->
-        if (pattern.contains('*') || pattern.contains('?')) {
-          matchesGlob(path, pattern)
-        } else {
-          pattern == path
-        }
-      }
-    }
-    // New patterns are always considered "new" (even if they overlap with existing ones)
-    return false
-  }
-  
-  /**
-   * Check if a path matches a glob pattern.
-   */
-  private fun matchesGlob(path: String, pattern: String): Boolean {
-    return try {
-      val pathMatcher = FileSystems.getDefault().getPathMatcher("glob:$pattern")
-      val pathToMatch = FileSystems.getDefault().getPath(path)
-      pathMatcher.matches(pathToMatch)
-    } catch (e: Exception) {
-      false
-    }
-  }
+  fun getUnsyncedPaths(): Set<String> = state.getUnsyncedPaths()
 
   override fun dispose() {}
 

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightModelDataService.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightModelDataService.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.externalSystem.model.project.ProjectData
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider
 import com.intellij.openapi.externalSystem.service.project.manage.AbstractProjectDataService
 import com.intellij.openapi.project.Project
+import com.intellij.ui.EditorNotifications
 
 /**
  * Data service that processes [SpotlightIdeModelData] after Gradle sync and updates the
@@ -23,8 +24,11 @@ class SpotlightModelDataService : AbstractProjectDataService<SpotlightIdeModelDa
   ) {
     val projectsService = SpotlightGradleProjectsService.getInstance(project)
     when (val data = toImport.firstOrNull()?.data) {
-      null -> projectsService.clearProjects()
+      // No Spotlight model means the Gradle plugin isn't applied to this project
+      null -> projectsService.markSpotlightNotApplied()
       else -> projectsService.updateProjects(data.includedProjectPaths)
     }
+    // Recompute editor banners now that we know whether Spotlight is applied
+    EditorNotifications.getInstance(project).updateAllNotifications()
   }
 }

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightSyncState.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightSyncState.kt
@@ -1,0 +1,237 @@
+package com.fueledbycaffeine.spotlight.idea.gradle
+
+import com.fueledbycaffeine.spotlight.buildscript.GradlePath
+import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList
+import com.fueledbycaffeine.spotlight.buildscript.SpotlightProjectList.Companion.ALL_PROJECTS_LOCATION
+import com.fueledbycaffeine.spotlight.buildscript.SpotlightRulesList.Companion.SPOTLIGHT_RULES_LOCATION
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+/**
+ * Whether the Spotlight Gradle plugin is applied, as determined by the most recent Gradle sync.
+ */
+enum class SpotlightPluginStatus {
+  /**
+   * No sync has completed yet and Spotlight's config files (all-projects.txt / spotlight-rules.json)
+   * exist, so it's likely set up but we can't yet confirm the plugin is applied to this build.
+   */
+  UNKNOWN,
+
+  /** The most recent sync produced a Spotlight model, so the plugin is applied. */
+  APPLIED,
+
+  /** The most recent sync completed without a Spotlight model, so the plugin is not applied. */
+  NOT_APPLIED,
+}
+
+/**
+ * Holds the Spotlight state captured from the most recent Gradle sync and the logic that decides
+ * whether the IDE needs to re-sync or show banners.
+ *
+ * This is intentionally free of IntelliJ platform types (it only needs the project root directory)
+ * so it can be unit-tested without the IDE test fixtures. [SpotlightGradleProjectsService] is a thin
+ * project-service wrapper around it.
+ */
+class SpotlightSyncState(private val rootDir: Path) {
+  // We only use this to read raw paths, so the allProjects lambda is not needed
+  private val ideProjectsList = SpotlightProjectList.ideProjects(rootDir) { emptySet() }
+  private val rulesPath = rootDir.resolve(SPOTLIGHT_RULES_LOCATION)
+  private val allProjectsPath = rootDir.resolve(ALL_PROJECTS_LOCATION)
+
+  private val _includedProjects = MutableStateFlow<Set<GradlePath>>(emptySet())
+
+  /**
+   * The normalized set of raw paths/patterns from ide-projects.txt at the time of the last sync.
+   * Used to detect meaningful changes that require a new sync.
+   */
+  private val _syncedRawPaths = MutableStateFlow<Set<String>>(emptySet())
+
+  /**
+   * The content of spotlight-rules.json at the time of the last sync.
+   * Used to detect changes that require a new sync.
+   */
+  @Volatile
+  private var _syncedRulesContent: String? = null
+
+  /**
+   * Whether at least one successful sync with Spotlight model data has completed.
+   */
+  @Volatile
+  private var _hasEverSynced = false
+
+  /**
+   * The plugin status established by the most recent sync. [SpotlightPluginStatus.UNKNOWN] until a
+   * sync completes; [pluginStatus] refines this with a file-based guess before the first sync.
+   */
+  @Volatile
+  private var _syncedStatus: SpotlightPluginStatus = SpotlightPluginStatus.UNKNOWN
+
+  /**
+   * Projects that were INCLUDED in the most recent Gradle sync.
+   * These are the projects that should be indexed in the IDE.
+   * Empty set indicates no sync has completed yet.
+   */
+  val includedProjects: StateFlow<Set<GradlePath>> = _includedProjects.asStateFlow()
+
+  /**
+   * Update the included projects from Gradle sync.
+   * Also records the current ide-projects.txt and spotlight-rules.json as the "synced" state.
+   */
+  fun updateProjects(projectPaths: Set<String>) {
+    val gradlePaths = projectPaths
+      .map { GradlePath(rootDir, it) }
+      // Filter results to match what spotlight parses from build files where intermediate and root
+      // projects are omitted
+      .filter { it.hasBuildFile && it.path != ":" }
+      .toSet()
+    _includedProjects.value = gradlePaths
+    _hasEverSynced = true
+    _syncedStatus = SpotlightPluginStatus.APPLIED
+
+    // Record the raw paths from ide-projects.txt at sync time
+    _syncedRawPaths.value = readCurrentRawPaths()
+    // Record the rules content at sync time
+    _syncedRulesContent = readCurrentRulesContent()
+  }
+
+  /**
+   * Check if Gradle sync has completed and we know which projects are included.
+   * Returns true once at least one sync has completed.
+   */
+  val hasSyncedProjects: Boolean get() = _includedProjects.value.isNotEmpty()
+
+  /**
+   * Check if at least one successful sync with Spotlight model data has completed.
+   */
+  val hasEverSynced: Boolean get() = _hasEverSynced
+
+  /**
+   * Whether the Spotlight Gradle plugin is applied.
+   *
+   * A completed sync is authoritative. Before the first sync we fall back to a best-effort guess
+   * from the presence of Spotlight's config files: if none exist, Spotlight isn't set up in this
+   * project at all so it can't be applied ([SpotlightPluginStatus.NOT_APPLIED]); otherwise we
+   * genuinely can't tell yet ([SpotlightPluginStatus.UNKNOWN]).
+   */
+  val pluginStatus: SpotlightPluginStatus
+    get() = when (_syncedStatus) {
+      SpotlightPluginStatus.APPLIED, SpotlightPluginStatus.NOT_APPLIED -> _syncedStatus
+      SpotlightPluginStatus.UNKNOWN ->
+        if (isSpotlightConfigured) SpotlightPluginStatus.UNKNOWN else SpotlightPluginStatus.NOT_APPLIED
+    }
+
+  // Spotlight's committed config files; absence of both means it isn't set up in this project.
+  private val isSpotlightConfigured: Boolean
+    get() = allProjectsPath.exists() || rulesPath.exists()
+
+  /**
+   * Record that a sync completed without a Spotlight model, meaning the Spotlight Gradle
+   * plugin is not applied to this project. Clears any stale included-projects state from a
+   * previous sync so banners and exclusions don't act on outdated data.
+   */
+  fun markSpotlightNotApplied() {
+    _includedProjects.value = emptySet()
+    _syncedRawPaths.value = emptySet()
+    _syncedRulesContent = null
+    _syncedStatus = SpotlightPluginStatus.NOT_APPLIED
+  }
+
+  /**
+   * Check if the current ide-projects.txt or spotlight-rules.json has meaningful changes
+   * compared to what was synced, or if no sync has ever completed.
+   * Returns true if sync is needed.
+   */
+  fun isSyncStale(): Boolean {
+    // The Spotlight Gradle plugin isn't applied (either a sync proved it, or there are no config
+    // files), so there's nothing to sync. Don't show banners even if a stale ide-projects.txt is
+    // lying around.
+    if (pluginStatus == SpotlightPluginStatus.NOT_APPLIED) return false
+
+    // If no sync has ever completed, it's stale (needs initial sync)
+    if (!_hasEverSynced) {
+      // Only consider stale if there's content in ide-projects.txt
+      return readCurrentRawPaths().isNotEmpty()
+    }
+
+    // Check if rules have changed
+    if (haveRulesChanged()) return true
+
+    // Check if ide-projects.txt has new paths
+    val currentPaths = readCurrentRawPaths()
+    val syncedPaths = _syncedRawPaths.value
+
+    // Find paths that are in current but not in synced
+    val newPaths = currentPaths - syncedPaths
+    if (newPaths.isEmpty()) return false
+
+    // Check if any new path is NOT covered by existing synced patterns
+    return newPaths.any { newPath -> !isPathCoveredByPatterns(newPath, syncedPaths) }
+  }
+
+  /**
+   * Check if spotlight-rules.json has changed since the last sync.
+   */
+  fun haveRulesChanged(): Boolean {
+    val currentRules = readCurrentRulesContent()
+    val syncedRules = _syncedRulesContent
+    return currentRules != syncedRules
+  }
+
+  /**
+   * Returns the set of new paths/patterns in ide-projects.txt that aren't covered by the synced state.
+   */
+  fun getUnsyncedPaths(): Set<String> {
+    if (!hasSyncedProjects) return emptySet()
+
+    val currentPaths = readCurrentRawPaths()
+    val syncedPaths = _syncedRawPaths.value
+
+    val newPaths = currentPaths - syncedPaths
+    return newPaths.filter { newPath -> !isPathCoveredByPatterns(newPath, syncedPaths) }.toSet()
+  }
+
+  private fun readCurrentRawPaths(): Set<String> {
+    return ideProjectsList.readRawPaths(includeComments = false)
+      .map { it.trim() }
+      .toSet()
+  }
+
+  private fun readCurrentRulesContent(): String? {
+    return if (rulesPath.exists()) {
+      rulesPath.readText()
+    } else {
+      null
+    }
+  }
+
+  private fun isPathCoveredByPatterns(path: String, patterns: Set<String>): Boolean {
+    // Direct paths are not covered by anything else (must be exact match)
+    if (!path.contains('*') && !path.contains('?')) {
+      // Check if any pattern in patterns covers this path
+      return patterns.any { pattern ->
+        if (pattern.contains('*') || pattern.contains('?')) {
+          matchesGlob(path, pattern)
+        } else {
+          pattern == path
+        }
+      }
+    }
+    // New patterns are always considered "new" (even if they overlap with existing ones)
+    return false
+  }
+
+  private fun matchesGlob(path: String, pattern: String): Boolean {
+    return try {
+      val pathMatcher = FileSystems.getDefault().getPathMatcher("glob:$pattern")
+      val pathToMatch = FileSystems.getDefault().getPath(path)
+      pathMatcher.matches(pathToMatch)
+    } catch (e: Exception) {
+      false
+    }
+  }
+}

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/notification/ProjectStaleNotificationProvider.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/notification/ProjectStaleNotificationProvider.kt
@@ -5,6 +5,7 @@ import com.fueledbycaffeine.spotlight.idea.SpotlightBundle
 import com.fueledbycaffeine.spotlight.idea.SpotlightProjectService
 import com.fueledbycaffeine.spotlight.idea.gradle.GradleSystemUtils
 import com.fueledbycaffeine.spotlight.idea.gradle.SpotlightGradleProjectsService
+import com.fueledbycaffeine.spotlight.idea.gradle.SpotlightPluginStatus
 import com.fueledbycaffeine.spotlight.idea.utils.findContainingProject
 import com.intellij.openapi.components.service
 import com.intellij.openapi.externalSystem.importing.ImportSpecBuilder
@@ -33,6 +34,12 @@ class ProjectStaleNotificationProvider(project: Project) : EditorNotificationPro
     project: Project,
     file: VirtualFile
   ): Function<in FileEditor, out JComponent?>? {
+    // If the most recent sync proved the Spotlight Gradle plugin isn't applied, there's
+    // nothing to index and no banner should ever be shown.
+    if (gradleProjectsService.pluginStatus == SpotlightPluginStatus.NOT_APPLIED) {
+      return null
+    }
+
     // Prefer gradle state over spotlight service state if available
     val hasGradleState = gradleProjectsService.hasSyncedProjects
     val indexedProjects = if (hasGradleState) {

--- a/spotlight-idea-plugin/src/test/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightSyncStateTest.kt
+++ b/spotlight-idea-plugin/src/test/kotlin/com/fueledbycaffeine/spotlight/idea/gradle/SpotlightSyncStateTest.kt
@@ -1,0 +1,217 @@
+package com.fueledbycaffeine.spotlight.idea.gradle
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+/**
+ * Tests for [SpotlightSyncState], the state machine that decides whether the IDE should show
+ * Spotlight banners / re-sync. The key behavior under test is that once a sync proves the Spotlight
+ * Gradle plugin is NOT applied, no banners should be shown even if a stale `ide-projects.txt` is
+ * left over.
+ */
+class SpotlightSyncStateTest {
+
+  @get:Rule
+  val tmpFolder = TemporaryFolder()
+
+  private fun rootDir(): Path = tmpFolder.root.toPath()
+
+  private fun writeIdeProjects(vararg lines: String) {
+    val file = rootDir().resolve("gradle/ide-projects.txt")
+    file.parent.createDirectories()
+    file.writeText(lines.joinToString("\n"))
+  }
+
+  private fun writeRules(content: String) {
+    val file = rootDir().resolve("gradle/spotlight-rules.json")
+    file.parent.createDirectories()
+    file.writeText(content)
+  }
+
+  /** Write all-projects.txt, the committed file that indicates Spotlight is set up in the repo. */
+  private fun writeAllProjects(vararg lines: String) {
+    val file = rootDir().resolve("gradle/all-projects.txt")
+    file.parent.createDirectories()
+    file.writeText(lines.joinToString("\n"))
+  }
+
+  /** Create a project dir with a build file so [updateProjects] keeps the path. */
+  private fun createProject(gradlePath: String) {
+    val relative = gradlePath.removePrefix(":").replace(":", "/")
+    val dir = rootDir().resolve(relative)
+    dir.createDirectories()
+    dir.resolve("build.gradle").writeText("")
+  }
+
+  // ===== Tri-state plugin detection =====
+
+  @Test
+  fun `pluginStatus is UNKNOWN before any sync when config files exist`() {
+    // all-projects.txt is committed when Spotlight is set up, so pre-sync we can't yet confirm
+    // the plugin is applied to this build, but it's likely configured.
+    writeAllProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.UNKNOWN)
+  }
+
+  @Test
+  fun `pluginStatus is NOT_APPLIED before any sync when no config files exist`() {
+    // No all-projects.txt or spotlight-rules.json means Spotlight isn't set up in this project.
+    val state = SpotlightSyncState(rootDir())
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.NOT_APPLIED)
+  }
+
+  @Test
+  fun `pluginStatus is UNKNOWN before any sync when only spotlight-rules_json exists`() {
+    writeRules("""{ "implicit": [] }""")
+    val state = SpotlightSyncState(rootDir())
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.UNKNOWN)
+  }
+
+  @Test
+  fun `pluginStatus is APPLIED after a sync that produced a model`() {
+    createProject(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    state.updateProjects(setOf(":app"))
+
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.APPLIED)
+    assertThat(state.includedProjects.value.map { it.path }).containsExactly(":app")
+  }
+
+  @Test
+  fun `pluginStatus is NOT_APPLIED after a sync with no model`() {
+    val state = SpotlightSyncState(rootDir())
+
+    state.markSpotlightNotApplied()
+
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.NOT_APPLIED)
+    assertThat(state.includedProjects.value).isEmpty()
+  }
+
+  // ===== The bug: stale ide-projects.txt with the plugin not applied =====
+
+  @Test
+  fun `configured but not yet synced shows initial-sync banner`() {
+    // Spotlight is set up (all-projects.txt committed) and the user has selected projects, but no
+    // sync has run yet. The initial-sync banner is expected; the fix must NOT regress this.
+    writeAllProjects(":app")
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.UNKNOWN)
+    assertThat(state.isSyncStale()).isTrue()
+  }
+
+  @Test
+  fun `not configured and not yet synced shows no banner`() {
+    // A leftover ide-projects.txt with no committed Spotlight config: Spotlight isn't set up here,
+    // so even before a sync we infer NOT_APPLIED and suppress the banner.
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.NOT_APPLIED)
+    assertThat(state.isSyncStale()).isFalse()
+  }
+
+  @Test
+  fun `fix - sync without plugin suppresses stale banner even with leftover ide-projects_txt`() {
+    // Leftover ide-projects.txt that would otherwise trigger the banner.
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    // Sync completes but the Spotlight Gradle plugin is not applied (no model).
+    state.markSpotlightNotApplied()
+
+    // No banner should be shown because we now know the plugin isn't applied.
+    assertThat(state.isSyncStale()).isFalse()
+  }
+
+  @Test
+  fun `fix - sync without plugin suppresses stale banner even when rules file exists`() {
+    writeIdeProjects(":app")
+    writeRules("""{ "implicit": [] }""")
+    val state = SpotlightSyncState(rootDir())
+
+    state.markSpotlightNotApplied()
+
+    assertThat(state.isSyncStale()).isFalse()
+  }
+
+  @Test
+  fun `fix - sync without plugin and no config files shows no banner`() {
+    // Tony's case: no ide-projects.txt at all, plugin not applied.
+    val state = SpotlightSyncState(rootDir())
+
+    state.markSpotlightNotApplied()
+
+    assertThat(state.isSyncStale()).isFalse()
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.NOT_APPLIED)
+  }
+
+  // ===== Regression guard: normal stale detection still works when plugin IS applied =====
+
+  @Test
+  fun `synced with plugin - no changes is not stale`() {
+    createProject(":app")
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    state.updateProjects(setOf(":app"))
+
+    assertThat(state.isSyncStale()).isFalse()
+  }
+
+  @Test
+  fun `synced with plugin - new path added becomes stale`() {
+    createProject(":app")
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+    state.updateProjects(setOf(":app"))
+
+    // User adds a new project to ide-projects.txt after sync.
+    writeIdeProjects(":app", ":lib")
+
+    assertThat(state.isSyncStale()).isTrue()
+    assertThat(state.getUnsyncedPaths()).containsExactly(":lib")
+  }
+
+  @Test
+  fun `synced with plugin - changed rules becomes stale`() {
+    createProject(":app")
+    writeIdeProjects(":app")
+    writeRules("""{ "implicit": [] }""")
+    val state = SpotlightSyncState(rootDir())
+    state.updateProjects(setOf(":app"))
+
+    assertThat(state.isSyncStale()).isFalse()
+
+    writeRules("""{ "implicit": [":app"] }""")
+
+    assertThat(state.haveRulesChanged()).isTrue()
+    assertThat(state.isSyncStale()).isTrue()
+  }
+
+  @Test
+  fun `re-sync after plugin removed flips state back to not applied`() {
+    createProject(":app")
+    writeIdeProjects(":app")
+    val state = SpotlightSyncState(rootDir())
+
+    // First sync: plugin applied.
+    state.updateProjects(setOf(":app"))
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.APPLIED)
+
+    // Branch switch / plugin removed: next sync has no model.
+    state.markSpotlightNotApplied()
+
+    assertThat(state.pluginStatus).isEqualTo(SpotlightPluginStatus.NOT_APPLIED)
+    assertThat(state.includedProjects.value).isEmpty()
+    assertThat(state.isSyncStale()).isFalse()
+  }
+}


### PR DESCRIPTION
Track plugin status as a tri-state from the most recent sync, falling back to config-file presence before the first sync, instead of inferring it from an empty included-projects set. Banners and directory exclusions now bail when the plugin is known to be not applied.