### PR TITLE
Update dependency versions

### DIFF
--- a/.github/workflows/functionalTest.yml
+++ b/.github/workflows/functionalTest.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         gradle_version:
           - 8.8
-          - 8.14.2
-          - 9.6.0
+          - 8.14.5
+          - 9.6.1
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/buildscript-utils/build.gradle
+++ b/buildscript-utils/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 kotlin {
   explicitApi()
 
+  compilerOptions {
+    allWarningsAsErrors.set(true)
+  }
+
   abiValidation {
     enabled.set(true)
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,17 +3,17 @@ javaTarget = "17"
 # This is currently the minimum Gradle version that has the APIs we need to use.
 minGradle = "8.8"
 
-develocity = "4.3"
-junit = "5.12.2"
+develocity = "4.5.0"
+junit = "6.1.2"
 junit4 = "4.13.2"
 assertk = "0.28.1"
-truth = "1.4.4"
-testkit = "0.18"
-testkit-support = "0.26"
-lint-gradle = "1.0.0-alpha05"
+truth = "1.4.5"
+testkit = "0.19"
+testkit-support = "0.27"
+lint-gradle = "1.0.0"
 moshi = "1.15.2"
-moshix = "0.34.4"
-okio = "3.16.2"
+moshix = "0.37.0"
+okio = "3.18.1"
 
 [libraries]
 develocity = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,34 +1,22 @@
 pluginManagement {
   plugins {
-    id 'com.gradle.develocity' version '4.4.3'
+    id 'com.gradle.develocity' version '4.5.0'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
-    id 'org.jetbrains.kotlin.jvm' version '2.4.0'
-    id 'dev.zacsweers.moshix' version '0.36.0'
-    id 'com.autonomousapps.testkit' version '0.18'
-    id 'com.autonomousapps.build-health' version '3.15.0'
+    id 'org.jetbrains.kotlin.jvm' version '2.4.10'
+    id 'dev.zacsweers.moshix' version '0.37.0'
+    id 'com.autonomousapps.testkit' version '0.19'
+    id 'com.autonomousapps.build-health' version '3.18.0'
     id 'com.gradle.plugin-publish' version '2.1.1'
     id 'org.gradle.plugin-compatibility' version '1.0.0'
     id 'com.vanniktech.maven.publish' version '0.37.0'
-    id 'com.android.lint' version '9.2.1'
-    id 'org.jetbrains.intellij.platform' version '2.16.0'
+    id 'com.android.lint' version '9.3.1'
+    id 'org.jetbrains.intellij.platform' version '2.18.1'
     id 'com.fueledbycaffeine.autoservice' version '0.1.5'
   }
   repositories {
     gradlePluginPortal()
     mavenCentral()
     google()
-  }
-}
-
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    // DAGP (build-health) reads Kotlin metadata from compiled classes. The bundled
-    // kotlin-metadata-jvm only supports older metadata versions, so it must be overridden
-    // to match the project's Kotlin version to parse newer metadata (e.g. 2.4.0).
-    classpath 'org.jetbrains.kotlin:kotlin-metadata-jvm:2.4.0'
   }
 }
 

--- a/spotlight-gradle-plugin/build.gradle
+++ b/spotlight-gradle-plugin/build.gradle
@@ -65,6 +65,10 @@ mavenPublishing {
 kotlin {
   explicitApi()
 
+  compilerOptions {
+    allWarningsAsErrors.set(true)
+  }
+
   abiValidation {
     enabled.set(true)
   }

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
@@ -147,7 +147,6 @@ class SpotlightSyncFunctionalTest {
     val project = SpiritboxProject().build()
     project.ideProjects.writeText(":rotoscope")
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
-    1
     // When
     val syncResult1 = project.sync()
     val syncResult2 = project.sync()
@@ -163,7 +162,6 @@ class SpotlightSyncFunctionalTest {
     val project = SpiritboxProject().build()
     project.ideProjects.writeText(":rotoscope")
     project.setGradleProperties("org.gradle.unsafe.isolated-projects" to "true")
-    1
     // When
     val syncResult1 = project.sync()
     project.rootDir.resolve("settings.gradle")

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/BuildResult.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/fixtures/BuildResult.kt
@@ -37,21 +37,15 @@ private val GITHUB_ACTIONS_STUFF = listOf(
   "DEVELOCITY_INJECTION_ENABLED",
   "develocity-injection.enabled",
 )
-private val DEVELOCITY_PLUGIN_STUFF = listOf<String>(
-  "com.gradle.scan.multi-application",
-  "develocity.deprecation.muteWarnings",
-  "develocity.deprecation.captureOrigin",
-  "develocity.deprecation.displayFullStackTrace",
-  "develocity.projectId",
-  "DEVELOCITY_SERVER_HTTP_PROXY_HOST",
-  "DEVELOCITY_SERVER_HTTP_PROXY_PORT",
-  "DEVELOCITY_SERVER_HTTPS_PROXY_HOST",
-  "DEVELOCITY_SERVER_HTTPS_PROXY_PORT",
-  "DEVELOCITY_SERVER_SOCKS_PROXY_HOST",
-  "DEVELOCITY_SERVER_SOCKS_PROXY_PORT",
-  "develocity.server.publicOverride",
-  "com.gradle.enterprise.server.publicOverride",
-)
+// The Develocity plugin reads many of its own properties, environment variables, and files at
+// configuration time (proxy settings, mTLS certs, artifact cache markers, etc). The exact set
+// varies by plugin version, so match by prefix rather than exact name.
+private fun CCDiagnostic.Input.isDevelocityInput(): Boolean {
+  return name.startsWith("develocity.") ||
+    name.startsWith("DEVELOCITY_") ||
+    name.startsWith("com.gradle.") ||
+    ".develocity/" in name
+}
 
 data class CCReport(
   val diagnostics: List<CCDiagnostic>,
@@ -147,7 +141,7 @@ private fun readConfigurationCacheReport(logLines: List<String>): CCReport {
   return report.copy(
     diagnostics = report.diagnostics
       .filter { it.input.name !in GITHUB_ACTIONS_STUFF }
-      .filter { it.input.name !in DEVELOCITY_PLUGIN_STUFF }
+      .filter { !it.input.isDevelocityInput() }
   )
 }
 

--- a/spotlight-idea-plugin/build.gradle
+++ b/spotlight-idea-plugin/build.gradle
@@ -18,6 +18,7 @@ repositories {
 
 kotlin {
   compilerOptions {
+    allWarningsAsErrors.set(true)
     jvmTarget.set(JvmTarget.JVM_21)
     // Inherit platform interface default methods directly instead of generating
     // legacy compatibility bridges, which otherwise reference deprecated APIs
@@ -32,7 +33,7 @@ java {
   }
 }
 
-def intellijTarget = "2026.1.3"
+def intellijTarget = "2026.2.0.1"
 
 dependencies {
   implementation project(":buildscript-utils")

--- a/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/json/SpotlightRulesCompletionContributor.kt
+++ b/spotlight-idea-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/idea/json/SpotlightRulesCompletionContributor.kt
@@ -97,7 +97,7 @@ private class SpotlightRulesCompletionProvider : CompletionProvider<CompletionPa
     while (current != null && current !is JsonStringLiteral) {
       current = current.parent
     }
-    return current as? JsonStringLiteral
+    return current
   }
   
   /**


### PR DESCRIPTION
Develocity 4.5.0 registers many new configuration cache inputs, so the functional test fixture now filters Develocity inputs by prefix instead of an exact name list.