### PR TITLE
Add task invocation rules to `spotlight-rules.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+#### Gradle Plugin
+* Add `taskInvocationRules` to `spotlight-rules.json` for including projects (or all projects) when specific tasks are invoked
+
 ### 1.6.12
 #### Gradle Plugin
 * Declare support for configuration cache

--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ Implicit rules apply to all Gradle invocations (sync and task execution).
 
 If you are using the `buildscript-utils` package by itself, you can read this rules list using the `SpotlightRulesList` class.
 
+### Task invocation rules
+Some plugins register tasks that operate on projects Spotlight cannot discover by parsing buildscripts. For example, [Dependency Analysis Gradle Plugin][dagp]'s `:buildHealth` root project task aggregates results from every project in the build, but the root project's buildscript doesn't necessarily declare a dependency on every other project in the build.
+
+Task invocation rules include additional projects (or all of them) when specific tasks are requested on the command line:
+
+```json5
+// gradle/spotlight-rules.json
+{
+  "taskInvocationRules": [
+    // Include all projects when :buildHealth is invoked
+    {
+      "taskNames": ["buildHealth"],
+      "includeAllProjects": true
+    },
+    // Include specific projects when a task is invoked
+    {
+      "taskNames": ["generateProtos"],
+      "includedProjects": [
+        ":proto-common"
+      ]
+    }
+  ]
+}
+```
+
+`taskNames` entries are the full, unqualified task names and are matched exactly, so abbreviated invocations (`./gradlew :bH`) will not match a rule declaring `buildHealth`. Project path qualifiers are ignored, so `./gradlew :foo:buildHealth` matches a rule declaring `buildHealth`.
+
 ### Type-safe Project Accessors
 Spotlight automatically parses [type-safe project accessors][typesafe-project-accessors] in your buildscripts and maps them to the corresponding project paths. This works with any project naming convention.
 
@@ -209,3 +236,4 @@ You can still add `include`s to `settings.gradle(.kts)` in your build outside of
 [typesafe-project-accessors]: https://docs.gradle.org/current/userguide/declaring_dependencies_basics.html#sec:type-safe-project-accessors
 [kts-accessors-bad]: https://www.zacsweers.dev/dont-use-type-safe-project-accessors-with-kotlin-gradle-dsl/
 [serviceloader]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html
+[dagp]: https://github.com/autonomousapps/dependency-analysis-gradle-plugin

--- a/buildscript-utils/api/buildscript-utils.api
+++ b/buildscript-utils/api/buildscript-utils.api
@@ -270,13 +270,15 @@ public abstract interface class com/fueledbycaffeine/spotlight/buildscript/model
 public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules {
 	public static final field Companion Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
-	public final fun copy (Ljava/util/Set;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
-	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;Ljava/util/Set;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/Set;Ljava/util/Set;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getImplicitRules ()Ljava/util/Set;
+	public final fun getTaskInvocationRules ()Ljava/util/Set;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -286,6 +288,30 @@ public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRu
 }
 
 public final class com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRulesJsonAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule {
+	public fun <init> (Ljava/util/Set;Ljava/util/Set;Z)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/util/Set;Ljava/util/Set;Z)Lcom/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule;
+	public static synthetic fun copy$default (Lcom/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule;Ljava/util/Set;Ljava/util/Set;ZILjava/lang/Object;)Lcom/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeAllProjects ()Z
+	public final fun getIncludedProjects ()Ljava/util/Set;
+	public final fun getTaskNames ()Ljava/util/Set;
+	public fun hashCode ()I
+	public final fun matches (Ljava/util/List;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRuleJsonAdapter : com/squareup/moshi/JsonAdapter {
 	public fun <init> (Lcom/squareup/moshi/Moshi;)V
 	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
 	public fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/SpotlightRules.kt
@@ -6,6 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 public data class SpotlightRules(
   val implicitRules: Set<ImplicitDependencyRule> = emptySet(),
+  val taskInvocationRules: Set<TaskInvocationRule> = emptySet(),
 ) {
   public companion object {
     public val EMPTY: SpotlightRules = SpotlightRules()

--- a/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule.kt
+++ b/buildscript-utils/src/main/kotlin/com/fueledbycaffeine/spotlight/buildscript/models/TaskInvocationRule.kt
@@ -1,0 +1,50 @@
+package com.fueledbycaffeine.spotlight.buildscript.models
+
+import com.fueledbycaffeine.spotlight.buildscript.GRADLE_PATH_SEP
+import com.fueledbycaffeine.spotlight.buildscript.GradlePath
+import com.squareup.moshi.JsonClass
+
+/**
+ * Rule for including projects when specific tasks are requested on the command line.
+ *
+ * Some plugins register tasks that operate on projects Spotlight cannot discover by parsing
+ * buildscripts, for example a task that aggregates results across every project in the build.
+ * This rule includes [includedProjects] (or every project, when [includeAllProjects] is true)
+ * whenever one of [taskNames] is requested.
+ *
+ * ```json
+ * {
+ *   "taskInvocationRules": [
+ *     {
+ *       "taskNames": ["buildHealth"],
+ *       "includeAllProjects": true
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * Task names are matched exactly, so abbreviated invocations like `./gradlew :bH` will not match
+ * a rule declaring `buildHealth`. Project path qualifiers are ignored; `:foo:check` and `check`
+ * both match a rule declaring `check`.
+ *
+ * @param taskNames Full task names (unqualified, e.g. `buildHealth`) that trigger this rule.
+ * @param includedProjects Projects to include in the build when this rule matches.
+ * @param includeAllProjects When true, all projects are included when this rule matches.
+ */
+@JsonClass(generateAdapter = true)
+public data class TaskInvocationRule(
+  val taskNames: Set<String>,
+  val includedProjects: Set<GradlePath> = emptySet(),
+  val includeAllProjects: Boolean = false,
+) {
+  /**
+   * Returns true if any of [taskRequestArgs] (the raw task request arguments from the command
+   * line) is one of this rule's [taskNames], ignoring any project path qualifier.
+   */
+  public fun matches(taskRequestArgs: List<String>): Boolean {
+    return taskRequestArgs.asSequence()
+      .filterNot { it.startsWith("-") }
+      .map { it.substringAfterLast(GRADLE_PATH_SEP) }
+      .any { it in taskNames }
+  }
+}

--- a/buildscript-utils/src/main/resources/schemas/spotlight-rules-schema.json
+++ b/buildscript-utils/src/main/resources/schemas/spotlight-rules-schema.json
@@ -11,6 +11,13 @@
       "items": {
         "$ref": "#/definitions/implicitDependencyRule"
       }
+    },
+    "taskInvocationRules": {
+      "type": "array",
+      "description": "A set of rules for including projects when specific tasks are requested on the command line",
+      "items": {
+        "$ref": "#/definitions/taskInvocationRule"
+      }
     }
   },
   "additionalProperties": false,
@@ -89,6 +96,30 @@
         }
       },
       "required": ["type", "pattern", "projectTemplate"],
+      "additionalProperties": false
+    },
+    "taskInvocationRule": {
+      "type": "object",
+      "title": "Task Invocation Rule",
+      "description": "Includes additional projects when one of the named tasks is requested on the command line",
+      "properties": {
+        "taskNames": {
+          "type": "array",
+          "description": "Full task names (unqualified, e.g. 'buildHealth') that trigger this rule. Names are matched exactly, ignoring any project path qualifier.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "includedProjects": {
+          "$ref": "#/definitions/projectPathArray"
+        },
+        "includeAllProjects": {
+          "type": "boolean",
+          "description": "When true, all projects are included in the build when this rule matches",
+          "default": false
+        }
+      },
+      "required": ["taskNames"],
       "additionalProperties": false
     },
     "projectPathArray": {

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/SpotlightRulesListTest.kt
@@ -109,6 +109,44 @@ class SpotlightRulesListTest {
   }
 
   @Test
+  fun `can read task invocation rules from file`() {
+    val rulesFile = tempDir.resolve(SpotlightRulesList.SPOTLIGHT_RULES_LOCATION)
+    rulesFile.createParentDirectories()
+    rulesFile.writeText(
+      """
+      {
+        "implicitRules": [
+          {
+            "type": "project-path-match-rule",
+            "pattern": ":foo",
+            "includedProjects": [":bar"]
+          }
+        ],
+        "taskInvocationRules": [
+          {
+            "taskNames": ["buildHealth"],
+            "includeAllProjects": true
+          },
+          {
+            "taskNames": ["checkThing", "verifyThing"],
+            "includedProjects": [":thing-support"]
+          }
+        ]
+      }
+      """.trimIndent()
+    )
+    val rules = SpotlightRulesList(tempDir).read()
+    assertThat(rules.implicitRules).hasSize(1)
+    assertThat(rules.taskInvocationRules).hasSize(2)
+    val includeAllRule = rules.taskInvocationRules.first { it.includeAllProjects }
+    assertThat(includeAllRule.taskNames).isEqualTo(setOf("buildHealth"))
+    assertThat(includeAllRule.includedProjects).isEmpty()
+    val includedProjectsRule = rules.taskInvocationRules.first { !it.includeAllProjects }
+    assertThat(includedProjectsRule.taskNames).isEqualTo(setOf("checkThing", "verifyThing"))
+    assertThat(includedProjectsRule.includedProjects).isEqualTo(setOf(GradlePath(tempDir, ":thing-support")))
+  }
+
+  @Test
   fun `can read buildscript-capture-rule from file`() {
     val rulesFile = tempDir.resolve(SpotlightRulesList.SPOTLIGHT_RULES_LOCATION)
     rulesFile.createParentDirectories()

--- a/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/TaskInvocationRuleTest.kt
+++ b/buildscript-utils/src/test/kotlin/com/fueledbycaffeine/spotlight/buildscript/TaskInvocationRuleTest.kt
@@ -1,0 +1,40 @@
+package com.fueledbycaffeine.spotlight.buildscript
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.fueledbycaffeine.spotlight.buildscript.models.TaskInvocationRule
+import org.junit.jupiter.api.Test
+
+class TaskInvocationRuleTest {
+  private val rule = TaskInvocationRule(taskNames = setOf("buildHealth"), includeAllProjects = true)
+
+  @Test
+  fun `matches unqualified task name`() {
+    assertThat(rule.matches(listOf("buildHealth"))).isTrue()
+  }
+
+  @Test
+  fun `matches qualified task paths`() {
+    assertThat(rule.matches(listOf(":buildHealth"))).isTrue()
+    assertThat(rule.matches(listOf(":foo:buildHealth"))).isTrue()
+  }
+
+  @Test
+  fun `matches any requested task`() {
+    assertThat(rule.matches(listOf(":app:assemble", "buildHealth"))).isTrue()
+  }
+
+  @Test
+  fun `ignores command line options`() {
+    assertThat(rule.matches(listOf("--stacktrace"))).isFalse()
+    assertThat(rule.matches(listOf("assemble", "--tests", "SomeTest"))).isFalse()
+  }
+
+  @Test
+  fun `does not match other tasks`() {
+    assertThat(rule.matches(listOf(":app:assemble"))).isFalse()
+    assertThat(rule.matches(listOf("help"))).isFalse()
+    assertThat(rule.matches(emptyList())).isFalse()
+  }
+}

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightBuildFunctionalTest.kt
@@ -221,6 +221,102 @@ class SpotlightBuildFunctionalTest {
   }
 
   @Test
+  fun `task invocation rules can include all projects`() {
+    // Given
+    val project = SpiritboxProject().build()
+    project.rootDir.resolve("build.gradle")
+      .appendText("\ntasks.register('buildHealth') { doLast {} }\n")
+    val rules = project.rootDir.resolve("gradle/spotlight-rules.json")
+    rules.writeText("""
+    {
+      "taskInvocationRules": [
+        {
+          "taskNames": ["buildHealth"],
+          "includeAllProjects": true
+        }
+      ]
+    }
+    """.trimIndent())
+
+    // When
+    val result = project.build(":buildHealth")
+
+    // Then
+    assertThat(result).task(":buildHealth").succeeded()
+    val includedProjects = result.includedProjects()
+    val expectedProjects = listOf(project.rootProject.settingsScript.rootProjectName) +
+      project.allProjects.readLines().filter { it.isNotBlank() }
+    assertThat(includedProjects).containsExactlyElementsIn(expectedProjects)
+    val ccReport = result.ccReport()
+    assertThat(ccReport.inputs).containsExactlyElementsIn(SPOTLIGHT_INPUTS)
+  }
+
+  @Test
+  fun `task invocation rules can include specific projects`() {
+    // Given
+    val project = SpiritboxProject().build()
+    val rules = project.rootDir.resolve("gradle/spotlight-rules.json")
+    rules.writeText("""
+    {
+      "taskInvocationRules": [
+        {
+          "taskNames": ["assemble"],
+          "includedProjects": [":the-fear-of-fear"]
+        }
+      ]
+    }
+    """.trimIndent())
+
+    // When
+    val result = project.build(":rotoscope:assemble")
+
+    // Then
+    assertThat(result).task(":rotoscope:assemble").succeeded()
+    val includedProjects = result.includedProjects()
+    val expectedProjects = listOf(
+      project.rootProject.settingsScript.rootProjectName,
+      ":rotoscope",
+      ":rotoscope:rotoscope",
+      ":rotoscope:hysteria",
+      ":rotoscope:sew-me-up",
+      // Included by the task invocation rule, along with its transitive dependencies
+      ":the-fear-of-fear",
+      ":the-fear-of-fear:cellar-door",
+      ":the-fear-of-fear:jaded",
+      ":the-fear-of-fear:too-close-too-late",
+      ":the-fear-of-fear:angel-eyes",
+      ":the-fear-of-fear:the-void",
+      ":the-fear-of-fear:ultraviolet",
+    )
+    assertThat(includedProjects).containsExactlyElementsIn(expectedProjects)
+  }
+
+  @Test
+  fun `task invocation rules do not match unrelated tasks`() {
+    // Given
+    val project = SpiritboxProject().build()
+    val rules = project.rootDir.resolve("gradle/spotlight-rules.json")
+    rules.writeText("""
+    {
+      "taskInvocationRules": [
+        {
+          "taskNames": ["buildHealth"],
+          "includeAllProjects": true
+        }
+      ]
+    }
+    """.trimIndent())
+
+    // When
+    val result = project.build(":help")
+
+    // Then
+    assertThat(result).task(":help").succeeded()
+    val includedProjects = result.includedProjects()
+    assertThat(includedProjects).containsExactly(project.rootProject.settingsScript.rootProjectName)
+  }
+
+  @Test
   fun `can include only the root project`() {
     // Given
     val project = SpiritboxProject().build()

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
@@ -57,24 +57,39 @@ internal abstract class SpotlightIncludedProjectsValueSource : ValueSource<Set<G
           allProjects.value
         }
       } else {
-        // TODO: why does start parameters never have a nonnull project path and the task paths are just listed in the args?
-        val taskPaths = guessProjectsFromTaskRequests(rootDirectory, parameters.taskRequests.get())
-        if (!taskPaths.isEmpty() && taskPaths.none { it.path.isEmpty() }) {
-          logger.info("Using transitives for projects of requested tasks")
-          implicitAndTransitiveDependenciesOf(taskPaths)
+        val taskRequests = parameters.taskRequests.get()
+        val matchedTaskRules = getSpotlightRules().taskInvocationRules
+          .filter { rule -> taskRequests.any { rule.matches(it.args) } }
+        if (matchedTaskRules.any { it.includeAllProjects }) {
+          logger.info(
+            "Task invocation rules matched the requested tasks, all projects will be loaded from {}",
+            SpotlightProjectList.ALL_PROJECTS_LOCATION,
+          )
+          getAllProjects()
         } else {
-          val projectDir = parameters.projectDir.getOrNull()?.asFile?.toPath()
-          val target = projectDir?.gradlePathRelativeTo(rootDirectory)
-          if (target != null && !target.isRootProject) {
-            val childProjects = target.expandChildProjects()
-            val projectsFromWorkingDir = when (target.hasBuildFile) {
-              true -> childProjects + target
-              else -> childProjects
-            }
-            logger.info("Gradle project dir given (-p), using child projects and transitives of {}", target.path)
-            implicitAndTransitiveDependenciesOf(projectsFromWorkingDir)
+          val taskRuleProjects = matchedTaskRules.flatMapTo(mutableSetOf()) { it.includedProjects }
+          if (taskRuleProjects.isNotEmpty()) {
+            logger.info("Task invocation rules matched the requested tasks, adding {} projects", taskRuleProjects.size)
+          }
+          // TODO: why does start parameters never have a nonnull project path and the task paths are just listed in the args?
+          val taskPaths = guessProjectsFromTaskRequests(rootDirectory, taskRequests)
+          if (!taskPaths.isEmpty() && taskPaths.none { it.path.isEmpty() }) {
+            logger.info("Using transitives for projects of requested tasks")
+            implicitAndTransitiveDependenciesOf(taskPaths + taskRuleProjects)
           } else {
-            getAllProjects()
+            val projectDir = parameters.projectDir.getOrNull()?.asFile?.toPath()
+            val target = projectDir?.gradlePathRelativeTo(rootDirectory)
+            if (target != null && !target.isRootProject) {
+              val childProjects = target.expandChildProjects()
+              val projectsFromWorkingDir = when (target.hasBuildFile) {
+                true -> childProjects + target
+                else -> childProjects
+              }
+              logger.info("Gradle project dir given (-p), using child projects and transitives of {}", target.path)
+              implicitAndTransitiveDependenciesOf(projectsFromWorkingDir + taskRuleProjects)
+            } else {
+              getAllProjects()
+            }
           }
         }
       }


### PR DESCRIPTION
Similar goal as #127, but made available to the build author so they don't have to depend on plugin authors adopting spotlight-specific code.