### PR TITLE
Improve configuration cache invalidation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+#### Gradle Plugin
+* Improve configuration cache invalidation messages for changes to included projects
+
 ### 1.7.1
 #### IDE plugin
 * Add diff preview support to quick-fix actions

--- a/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
+++ b/spotlight-gradle-plugin/src/functionalTest/kotlin/com/fueledbycaffeine/spotlight/functionaltest/SpotlightSyncFunctionalTest.kt
@@ -1,7 +1,6 @@
 package com.fueledbycaffeine.spotlight.functionaltest
 
 import com.fueledbycaffeine.spotlight.functionaltest.fixtures.CCDiagnostic.Input.Companion.SPOTLIGHT_INPUTS
-import com.fueledbycaffeine.spotlight.functionaltest.fixtures.CCDiagnostic.Input.Companion.SpotlightValueSource
 import com.fueledbycaffeine.spotlight.functionaltest.fixtures.SpiritboxProject
 import com.fueledbycaffeine.spotlight.functionaltest.fixtures.allProjects
 import com.fueledbycaffeine.spotlight.functionaltest.fixtures.ccReport
@@ -212,7 +211,7 @@ class SpotlightSyncFunctionalTest {
     // Then
     assertThat(syncResult1.configurationCacheStored).isTrue()
     assertThat(syncResult2.configurationCacheInvalidationReason)
-      .isEqualTo("a build logic input of type '${SpotlightValueSource.name}' has changed.")
+      .isEqualTo("the set of projects included by Spotlight has changed.")
     assertThat(syncResult2.configurationCacheReused).isFalse()
     assertThat(syncResult2.configurationCacheStored).isTrue()
   }

--- a/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
+++ b/spotlight-gradle-plugin/src/main/kotlin/com/fueledbycaffeine/spotlight/SpotlightIncludedProjectsValueSource.kt
@@ -12,6 +12,7 @@ import com.fueledbycaffeine.spotlight.utils.guessProjectsFromTaskRequests
 import com.fueledbycaffeine.spotlight.utils.isIdeSync
 import com.fueledbycaffeine.spotlight.utils.isSpotlightEnabled
 import org.gradle.TaskExecutionRequest
+import org.gradle.api.Describable
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.Logging
@@ -30,7 +31,9 @@ import kotlin.time.measureTimedValue
  * Wraps the operations to determine the list of included projects so that reading files here does
  * not get captured in configuration cache.
  */
-internal abstract class SpotlightIncludedProjectsValueSource : ValueSource<Set<GradlePath>, Params> {
+internal abstract class SpotlightIncludedProjectsValueSource : ValueSource<Set<GradlePath>, Params>, Describable {
+  override fun getDisplayName(): String = "the set of projects included by Spotlight"
+
   override fun obtain(): Set<GradlePath> {
     val projectsOverride = targetPathsOverride
     val projects = if (!parameters.spotlightEnabled.get()) {


### PR DESCRIPTION
Makes Spotlight configuration cache invalidation reasons easier to understand.